### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,6 +2,8 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/IKcoding-jp/maikago/security/code-scanning/1](https://github.com/IKcoding-jp/maikago/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to restrict the privileges granted to the GITHUB_TOKEN used in this workflow. This block should be added at the root of the workflow file (just below the `name` field and above `on:`), so that all jobs inherit the restricted permissions unless overridden. Based on typical usage for Firebase hosting deploy workflows and following CodeQL’s recommendation, we should set `contents: read` as the minimal starting point. If further permissions prove necessary for status reporting or other features, we can expand the block accordingly. The change only modifies the YAML header and does not affect any existing workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
