### PR TITLE
fix(ci): env.jsonの出力パスをプロジェクトルートに修正

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           channel: stable
       - run: flutter pub get
-      - run: echo '${{ secrets.ENV_JSON }}' > assets/env.json
+      - run: echo '${{ secrets.ENV_JSON }}' > env.json
       - run: flutter build web
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:


### PR DESCRIPTION
## Summary
- `env.json` の出力先が `assets/env.json` になっていたのを `env.json`（ルート直下）に修正
- `pubspec.yaml` では `env.json` としてルート直下を参照しているため

## Test plan
- [ ] main マージ後に `Deploy to Firebase Hosting on merge` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)