### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/IKcoding-jp/maikago/security/code-scanning/4](https://github.com/IKcoding-jp/maikago/security/code-scanning/4)

In general, this problem is fixed by adding an explicit `permissions` block to the workflow (at the root or per job) that grants only the scopes actually needed. For a pure CI/test job that just checks out code and runs analysis/tests, `contents: read` is typically sufficient; you may also omit `permissions` entirely but that reverts to repo defaults, which is what we want to avoid.

In this specific workflow, we should add a root-level `permissions` block (so it applies to all jobs) directly under the `name:` and `on:` section, before `jobs:`. The block should set `contents: read`, which is enough for `actions/checkout@v4` and for reading the code during the tests. No further permissions (like `pull-requests: write` or `issues: write`) are required based on the shown steps. No additional imports or methods are needed, as this is a YAML configuration change only.

Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` key (line 9). This will ensure the `GITHUB_TOKEN` has restricted, read-only access to repository contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
