### PR TITLE
fix(#41): 匿名セッションIDを暗号的に安全なUUIDv4に変更

### DIFF
--- a/lib/services/data_service.dart
+++ b/lib/services/data_service.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart';
 import 'dart:async'; // TimeoutException用
 import 'package:firebase_core/firebase_core.dart';
+import 'package:uuid/uuid.dart';
 import '../models/list.dart';
 import '../models/shop.dart';
 // debugPrintを追加
@@ -51,8 +52,8 @@ class DataService {
     String? sessionId = prefs.getString(_anonymousSessionKey);
 
     if (sessionId == null) {
-      // 新しいセッションIDを生成
-      sessionId = DateTime.now().millisecondsSinceEpoch.toString();
+      // 暗号的に安全なUUIDv4でセッションIDを生成
+      sessionId = const Uuid().v4();
       await prefs.setString(_anonymousSessionKey, sessionId);
     }
 


### PR DESCRIPTION
## Summary
- 匿名セッションIDの生成を `DateTime.now().millisecondsSinceEpoch` から `Uuid().v4()` に変更
- タイムスタンプベースの予測可能なIDを暗号的に安全なUUIDv4に置き換え、セッションハイジャックのリスクを排除
- `uuid` パッケージは既に依存関係に含まれているため、新規パッケージ追加は不要

## Changes
- `lib/services/data_service.dart`: `import 'package:uuid/uuid.dart'` を追加し、`_getAnonymousSessionId()` メソッド内のセッションID生成を `const Uuid().v4()` に変更

## Test plan
- [ ] 匿名ユーザーとしてアプリを起動し、買い物リストの追加・編集・削除が正常に動作すること
- [ ] セッションIDがUUID形式（例: `550e8400-e29b-41d4-a716-446655440000`）で生成されることを確認
- [ ] アプリ再起動後も同じセッションIDが `SharedPreferences` から復元されること
- [ ] `flutter analyze` でエラーがないこと (確認済み)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)