### PR TITLE
chore(#45): デッドコード・コメントアウトimportの削除

### DIFF
--- a/lib/ad/interstitial_ad_service.dart
+++ b/lib/ad/interstitial_ad_service.dart
@@ -16,10 +16,8 @@ class InterstitialAdService {
   InterstitialAd? _interstitialAd;
   bool _isAdLoaded = false;
   bool _isShowingAd = false;
-  int _adShowCount = 0;
   int _operationCount = 0;
   static const int _showAdEveryOperations = 3;
-  static const int _maxAdsPerSession = 999999;
   bool _wasPremium = false; // 前回のプレミアム状態を保持
 
   void _onPremiumStatusChanged() {
@@ -66,9 +64,7 @@ class InterstitialAdService {
       return;
     }
 
-    if (_isAdLoaded &&
-        _interstitialAd != null &&
-        _adShowCount < _maxAdsPerSession) {
+    if (_isAdLoaded && _interstitialAd != null) {
       debugPrint('🎯 プレミアム状態変化時にインタースティシャル広告を表示します');
       try {
         _isShowingAd = true;
@@ -139,7 +135,6 @@ class InterstitialAdService {
                 _isShowingAd = false;
                 ad.dispose();
                 _isAdLoaded = false;
-                _adShowCount++;
                 loadAd();
               },
               onAdFailedToShowFullScreenContent: (ad, error) {
@@ -210,13 +205,6 @@ class InterstitialAdService {
       return false;
     }
 
-    if (_adShowCount >= _maxAdsPerSession) {
-      debugPrint('🔧 インタースティシャル広告表示条件チェック: セッション内広告表示回数制限超過');
-      debugPrint(
-          '🔧   - _adShowCount: $_adShowCount, _maxAdsPerSession: $_maxAdsPerSession');
-      return false;
-    }
-
     final shouldShow = _operationCount % _showAdEveryOperations == 0;
     debugPrint('🔧 インタースティシャル広告表示条件チェック:');
     debugPrint('🔧   - _operationCount: $_operationCount');
@@ -245,7 +233,6 @@ class InterstitialAdService {
   }
 
   void resetSession() {
-    _adShowCount = 0;
     _operationCount = 0;
     _isShowingAd = false;
     loadAd();

--- a/lib/drawer/settings/settings_screen.dart
+++ b/lib/drawer/settings/settings_screen.dart
@@ -9,8 +9,6 @@ import 'settings_font.dart';
 import '../../services/one_time_purchase_service.dart';
 import '../../services/app_info_service.dart';
 import '../../providers/auth_provider.dart';
-// import '../../widgets/family_member_status_widget.dart'; // 削除済み
-// import '../../widgets/family_leave_button.dart'; // 削除済み
 import 'advanced_settings_screen.dart';
 import 'terms_of_service_screen.dart';
 import 'privacy_policy_screen.dart';

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -3,8 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'dart:async';
 
-import 'package:maikago/services/hybrid_ocr_service.dart';
-
 import '../providers/data_provider.dart';
 import '../providers/auth_provider.dart';
 import '../main.dart';
@@ -29,7 +27,6 @@ import '../drawer/maikago_premium.dart';
 import 'release_history_screen.dart';
 
 import '../services/one_time_purchase_service.dart';
-// import '../services/subscription_service.dart';
 import '../widgets/version_update_dialog.dart';
 import '../services/version_notification_service.dart';
 import '../models/release_history.dart';
@@ -38,7 +35,6 @@ import 'main/dialogs/sort_dialog.dart';
 import 'main/dialogs/item_edit_dialog.dart';
 import 'main/dialogs/tab_edit_dialog.dart';
 import 'main/widgets/bottom_summary_widget.dart';
-// vision_ocr_service is not used in this file; import removed to fix linter warning
 
 class MainScreen extends StatefulWidget {
   final void Function(ThemeData)? onThemeChanged;
@@ -76,12 +72,8 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     'surface': const Color(0xFFFFF1F8),
   };
   String nextShopId = '1';
-  String nextItemId = '0';
   bool includeTax = false;
   bool isDarkMode = false;
-
-  // ハイブリッドOCRサービス
-  final HybridOcrService _hybridOcrService = HybridOcrService();
 
   ThemeData getCustomTheme() {
     return SettingsTheme.generateTheme(
@@ -677,18 +669,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
       final authProvider = context.read<AuthProvider>();
       dataProvider.setAuthProvider(authProvider);
 
-      // ハイブリッドOCRサービスの初期化
-      _initializeHybridOcr();
     });
-  }
-
-  /// ハイブリッドOCRサービスの初期化
-  Future<void> _initializeHybridOcr() async {
-    try {
-      await _hybridOcrService.initialize();
-    } catch (e) {
-      debugPrint('❌ ハイブリッドOCR初期化エラー: $e');
-    }
   }
 
   @override
@@ -696,8 +677,6 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     tabController.dispose();
     // インタースティシャル広告の破棄
     InterstitialAdService().dispose();
-    // ハイブリッドOCRサービスの破棄
-    _hybridOcrService.dispose();
     super.dispose();
   }
 

--- a/lib/screens/ocr_result_confirm_screen.dart
+++ b/lib/screens/ocr_result_confirm_screen.dart
@@ -8,10 +8,6 @@ import '../models/list.dart';
 import '../models/shop.dart';
 import '../providers/data_provider.dart';
 import '../utils/dialog_utils.dart';
-// unused imports removed
-
-/// 保存モード
-// SaveMode enum is removed
 
 /// OCR結果確認・編集画面
 class OcrResultConfirmScreen extends StatefulWidget {


### PR DESCRIPTION
## 概要
Issue #45 を解決。デッドコード・コメントアウトimport・無効な設定値を削除してコードをクリーンアップ。

## 変更内容
- コメントアウトされたimport文を3ファイルから削除
- 未使用変数 `nextItemId` を削除
- 事実上無効な `_maxAdsPerSession=999999` 定数と関連条件チェック・`_adShowCount`変数を削除
- MainScreenのHybridOcrService二重初期化を解消（BottomSummaryWidgetに一本化）
- 不要コメント（`// unused imports removed`, `// SaveMode enum is removed`）を削除

### 対象外とした項目
- `includeTax` / `isDarkMode`: Issue記載と異なり実際に使用されているため削除不可
- `env.json`の`MAIKAGO_ENABLE_DEBUG_MODE`: env.jsonに存在しない（config.dartで管理）

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（65テスト全パス）
- [ ] コードレビュー
- [ ] 実機動作確認

Closes #45
