### PR TITLE
refactor(#38): debugPrint管理の統一（538箇所）

### DIFF
--- a/lib/ad/ad_banner.dart
+++ b/lib/ad/ad_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../services/one_time_purchase_service.dart';
 import '../config.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class AdBanner extends StatefulWidget {
   const AdBanner({super.key});
@@ -77,11 +78,11 @@ class _AdBannerState extends State<AdBanner> {
     // プレミアム状態をより確実にチェック
     if (purchaseService.isPremiumUnlocked) {
       if (!forceShowAdsForDebug) {
-        debugPrint(
+        DebugService().log(
             '[AdBanner] Skip loading banner because premium or trial is active.');
         return;
       } else {
-        debugPrint(
+        DebugService().log(
             '[AdBanner] Debug override active, proceeding to load banner.');
       }
     }
@@ -144,11 +145,11 @@ class _AdBannerState extends State<AdBanner> {
     final purchaseService = OneTimePurchaseService();
     if (purchaseService.isPremiumUnlocked) {
       if (!forceShowAdsForDebug) {
-        debugPrint(
+        DebugService().log(
             '[AdBanner] Hide banner because premium or trial is active.');
         return const SizedBox.shrink();
       } else {
-        debugPrint(
+        DebugService().log(
             '[AdBanner] Debug override active, keeping banner visible despite premium.');
       }
     }

--- a/lib/ad/app_open_ad_service.dart
+++ b/lib/ad/app_open_ad_service.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../services/one_time_purchase_service.dart';
 import '../config.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// アプリ起動広告（App Open Ads）管理マネージャー
 /// Googleドキュメントのベストプラクティスに基づく実装
@@ -75,23 +75,23 @@ class AppOpenAdManager {
   void loadAd() {
     try {
       if (isAdAvailable || _isShowingAd) {
-        debugPrint('🔧 アプリ起動広告: 既に読み込み済みまたは表示中のためスキップ');
+        DebugService().log('🔧 アプリ起動広告: 既に読み込み済みまたは表示中のためスキップ');
         return;
       }
 
       final purchaseService = OneTimePurchaseService();
       // 初期化完了を待つ
       if (!purchaseService.isInitialized) {
-        debugPrint('🔧 アプリ起動広告: OneTimePurchaseServiceの初期化待機中');
+        DebugService().log('🔧 アプリ起動広告: OneTimePurchaseServiceの初期化待機中');
         return;
       }
 
       if (purchaseService.isPremiumUnlocked) {
-        debugPrint('🔧 アプリ起動広告: プレミアムユーザーのため広告読み込みをスキップ');
+        DebugService().log('🔧 アプリ起動広告: プレミアムユーザーのため広告読み込みをスキップ');
         return;
       }
 
-      debugPrint(
+      DebugService().log(
           '🔧 アプリ起動広告: 広告読み込み開始（試行回数: ${_loadAttempts + 1}/$_maxLoadAttempts）');
 
       AppOpenAd.load(
@@ -99,18 +99,18 @@ class AppOpenAdManager {
         request: const AdRequest(),
         adLoadCallback: AppOpenAdLoadCallback(
           onAdLoaded: (ad) {
-            debugPrint('✅ アプリ起動広告: 読み込み成功');
+            DebugService().log('✅ アプリ起動広告: 読み込み成功');
             _appOpenAd = ad;
             _appOpenAdLoadTime = DateTime.now();
             _loadAttempts = 0; // 成功時はリセット
 
             _appOpenAd!.fullScreenContentCallback = FullScreenContentCallback(
               onAdShowedFullScreenContent: (ad) {
-                debugPrint('🔧 アプリ起動広告: 表示開始');
+                DebugService().log('🔧 アプリ起動広告: 表示開始');
                 _isShowingAd = true;
               },
               onAdDismissedFullScreenContent: (ad) {
-                debugPrint('🔧 アプリ起動広告: 表示終了');
+                DebugService().log('🔧 アプリ起動広告: 表示終了');
                 _isShowingAd = false;
                 ad.dispose();
                 _appOpenAd = null;
@@ -121,7 +121,7 @@ class AppOpenAdManager {
                 });
               },
               onAdFailedToShowFullScreenContent: (ad, error) {
-                debugPrint('❌ アプリ起動広告: 表示失敗 - $error');
+                DebugService().log('❌ アプリ起動広告: 表示失敗 - $error');
                 _isShowingAd = false;
                 ad.dispose();
                 _appOpenAd = null;
@@ -134,27 +134,27 @@ class AppOpenAdManager {
             );
           },
           onAdFailedToLoad: (error) {
-            debugPrint('❌ アプリ起動広告: 読み込み失敗 - $error');
+            DebugService().log('❌ アプリ起動広告: 読み込み失敗 - $error');
             _appOpenAd = null;
             _appOpenAdLoadTime = null;
             _loadAttempts++;
 
             if (_loadAttempts < _maxLoadAttempts) {
-              debugPrint(
+              DebugService().log(
                   '🔧 アプリ起動広告: リトライします（$_loadAttempts/$_maxLoadAttempts）');
               Future.delayed(Duration(seconds: 2 + _loadAttempts), () {
                 loadAd();
               });
             } else {
-              debugPrint('❌ アプリ起動広告: 最大試行回数に達したため読み込みを停止');
+              DebugService().log('❌ アプリ起動広告: 最大試行回数に達したため読み込みを停止');
               _loadAttempts = 0;
             }
           },
         ),
       );
     } catch (e, stackTrace) {
-      debugPrint('❌ アプリ起動広告読み込みエラー: $e');
-      debugPrint('❌ スタックトレース: $stackTrace');
+      DebugService().log('❌ アプリ起動広告読み込みエラー: $e');
+      DebugService().log('❌ スタックトレース: $stackTrace');
       _appOpenAd = null;
       _appOpenAdLoadTime = null;
     }
@@ -168,25 +168,25 @@ class AppOpenAdManager {
 
       // 初期化完了を待つ
       if (!purchaseService.isInitialized) {
-        debugPrint('🔧 アプリ起動広告: OneTimePurchaseServiceの初期化待機中');
+        DebugService().log('🔧 アプリ起動広告: OneTimePurchaseServiceの初期化待機中');
         return;
       }
 
       if (purchaseService.isPremiumUnlocked) {
-        debugPrint('🔧 アプリ起動広告: プレミアムユーザーのため広告表示をスキップ');
+        DebugService().log('🔧 アプリ起動広告: プレミアムユーザーのため広告表示をスキップ');
         return;
       }
 
       // 広告が利用可能かチェック
       if (!isAdAvailable) {
-        debugPrint('🔧 アプリ起動広告: 広告が読み込まれていないため読み込みを開始');
+        DebugService().log('🔧 アプリ起動広告: 広告が読み込まれていないため読み込みを開始');
         loadAd();
         return;
       }
 
       // 既に表示中の場合はスキップ
       if (_isShowingAd) {
-        debugPrint('🔧 アプリ起動広告: 既に表示中のためスキップ');
+        DebugService().log('🔧 アプリ起動広告: 既に表示中のためスキップ');
         return;
       }
 
@@ -195,7 +195,7 @@ class AppOpenAdManager {
           DateTime.now()
               .subtract(maxCacheDuration)
               .isAfter(_appOpenAdLoadTime!)) {
-        debugPrint('🔧 アプリ起動広告: 広告の有効期限切れのため再読み込み');
+        DebugService().log('🔧 アプリ起動広告: 広告の有効期限切れのため再読み込み');
         _appOpenAd!.dispose();
         _appOpenAd = null;
         _appOpenAdLoadTime = null;
@@ -205,23 +205,23 @@ class AppOpenAdManager {
 
       // 使用回数チェック
       if (_appUsageCount < _minUsageCountBeforeAd) {
-        debugPrint(
+        DebugService().log(
             '🔧 アプリ起動広告: 使用回数不足（$_appUsageCount/$_minUsageCountBeforeAd）');
         return;
       }
 
       // 広告表示前の最終チェック
       if (_appOpenAd == null) {
-        debugPrint('🔧 アプリ起動広告: 広告オブジェクトがnullのため表示をスキップ');
+        DebugService().log('🔧 アプリ起動広告: 広告オブジェクトがnullのため表示をスキップ');
         return;
       }
 
-      debugPrint('🔧 アプリ起動広告: 広告表示を開始');
+      DebugService().log('🔧 アプリ起動広告: 広告表示を開始');
       _isShowingAd = true;
       _appOpenAd!.show();
     } catch (e, stackTrace) {
-      debugPrint('❌ アプリ起動広告表示エラー: $e');
-      debugPrint('❌ スタックトレース: $stackTrace');
+      DebugService().log('❌ アプリ起動広告表示エラー: $e');
+      DebugService().log('❌ スタックトレース: $stackTrace');
       _isShowingAd = false;
 
       // エラー発生時は広告を破棄して再読み込み

--- a/lib/ad/interstitial_ad_service.dart
+++ b/lib/ad/interstitial_ad_service.dart
@@ -1,7 +1,7 @@
 import 'package:google_mobile_ads/google_mobile_ads.dart';
-import 'package:flutter/foundation.dart';
 import '../services/one_time_purchase_service.dart';
 import '../config.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class InterstitialAdService {
   static final InterstitialAdService _instance =
@@ -30,7 +30,7 @@ class InterstitialAdService {
 
     // プレミアムになった場合：広告を破棄
     if (isPremium && _interstitialAd != null) {
-      debugPrint('🔧 プレミアムになったため、インタースティシャル広告を破棄します');
+      DebugService().log('🔧 プレミアムになったため、インタースティシャル広告を破棄します');
       _interstitialAd?.dispose();
       _interstitialAd = null;
       _isAdLoaded = false;
@@ -38,7 +38,7 @@ class InterstitialAdService {
     }
     // プレミアムが切れた場合：広告を再読み込みし、プレミアム解除時の広告を表示する機会を増やす
     else if (!isPremium && !_isAdLoaded && !_isShowingAd) {
-      debugPrint('🔧 プレミアムが切れたため、インタースティシャル広告を再読み込みします');
+      DebugService().log('🔧 プレミアムが切れたため、インタースティシャル広告を再読み込みします');
       _wasPremium = false;
       // オペレーションカウントを調整して広告表示の機会を増やす
       if (_operationCount % _showAdEveryOperations != 0) {
@@ -65,12 +65,12 @@ class InterstitialAdService {
     }
 
     if (_isAdLoaded && _interstitialAd != null) {
-      debugPrint('🎯 プレミアム状態変化時にインタースティシャル広告を表示します');
+      DebugService().log('🎯 プレミアム状態変化時にインタースティシャル広告を表示します');
       try {
         _isShowingAd = true;
         await _interstitialAd!.show();
       } catch (e) {
-        debugPrint('❌ プレミアム状態変化時のインタースティシャル広告表示失敗: $e');
+        DebugService().log('❌ プレミアム状態変化時のインタースティシャル広告表示失敗: $e');
         _isShowingAd = false;
         _isAdLoaded = false;
         loadAd();
@@ -90,22 +90,22 @@ class InterstitialAdService {
       waitCount++;
     }
 
-    debugPrint('🔧 インタースティシャル広告読み込みチェック開始');
-    debugPrint('🔧 OneTimePurchaseService状態:');
-    debugPrint('🔧 isInitialized: ${purchaseService.isInitialized}');
-    debugPrint('🔧 isPremiumUnlocked: ${purchaseService.isPremiumUnlocked}');
-    debugPrint('🔧 isPremiumPurchased: ${purchaseService.isPremiumPurchased}');
-    debugPrint('🔧 isTrialActive: ${purchaseService.isTrialActive}');
-    debugPrint('🔧 デバッグモード設定値: $configEnableDebugMode');
+    DebugService().log('🔧 インタースティシャル広告読み込みチェック開始');
+    DebugService().log('🔧 OneTimePurchaseService状態:');
+    DebugService().log('🔧 isInitialized: ${purchaseService.isInitialized}');
+    DebugService().log('🔧 isPremiumUnlocked: ${purchaseService.isPremiumUnlocked}');
+    DebugService().log('🔧 isPremiumPurchased: ${purchaseService.isPremiumPurchased}');
+    DebugService().log('🔧 isTrialActive: ${purchaseService.isTrialActive}');
+    DebugService().log('🔧 デバッグモード設定値: $configEnableDebugMode');
 
     if (purchaseService.isPremiumUnlocked) {
-      debugPrint('🔧 プレミアムユーザーのため、インタースティシャル広告の読み込みをスキップします');
-      debugPrint('🔧 プレミアム状態の詳細:');
-      debugPrint(
+      DebugService().log('🔧 プレミアムユーザーのため、インタースティシャル広告の読み込みをスキップします');
+      DebugService().log('🔧 プレミアム状態の詳細:');
+      DebugService().log(
           '🔧   - isPremiumUnlocked: ${purchaseService.isPremiumUnlocked}');
-      debugPrint(
+      DebugService().log(
           '🔧   - isPremiumPurchased: ${purchaseService.isPremiumPurchased}');
-      debugPrint('🔧   - isTrialActive: ${purchaseService.isTrialActive}');
+      DebugService().log('🔧   - isTrialActive: ${purchaseService.isTrialActive}');
       return;
     }
 
@@ -114,9 +114,9 @@ class InterstitialAdService {
       await Future.delayed(const Duration(milliseconds: 5000));
 
       // デバッグモード時の設定
-      debugPrint('🔧 インタースティシャル広告読み込み開始');
-      debugPrint('🔧 インタースティシャル広告ID: $adInterstitialUnitId');
-      debugPrint(
+      DebugService().log('🔧 インタースティシャル広告読み込み開始');
+      DebugService().log('🔧 インタースティシャル広告ID: $adInterstitialUnitId');
+      DebugService().log(
           '🔧 現在の広告状態: _isAdLoaded=$_isAdLoaded, _isShowingAd=$_isShowingAd');
 
       await InterstitialAd.load(
@@ -124,8 +124,8 @@ class InterstitialAdService {
         request: const AdRequest(),
         adLoadCallback: InterstitialAdLoadCallback(
           onAdLoaded: (ad) {
-            debugPrint('✅ インタースティシャル広告読み込み成功');
-            debugPrint('🔧 インタースティシャル広告オブジェクト: ${ad.toString()}');
+            DebugService().log('✅ インタースティシャル広告読み込み成功');
+            DebugService().log('🔧 インタースティシャル広告オブジェクト: ${ad.toString()}');
             _interstitialAd = ad;
             _isAdLoaded = true;
 
@@ -150,14 +150,14 @@ class InterstitialAdService {
           },
           onAdFailedToLoad: (error) {
             _isAdLoaded = false;
-            debugPrint('❌ インタースティシャル広告読み込み失敗: ${error.message}');
-            debugPrint('🔍 エラーコード: ${error.code}');
-            debugPrint('🔍 エラー詳細: $error');
+            DebugService().log('❌ インタースティシャル広告読み込み失敗: ${error.message}');
+            DebugService().log('🔍 エラーコード: ${error.code}');
+            DebugService().log('🔍 エラー詳細: $error');
 
             if (error.message.contains('JavascriptEngine') ||
                 error.message.contains('WebView') ||
                 error.message.contains('Renderer')) {
-              debugPrint('🔄 WebViewエラーを検出、15秒後に再試行します');
+              DebugService().log('🔄 WebViewエラーを検出、15秒後に再試行します');
               Future.delayed(const Duration(seconds: 15), () {
                 loadAd();
               });
@@ -166,7 +166,7 @@ class InterstitialAdService {
         ),
       );
     } catch (e) {
-      debugPrint('❌ インタースティシャル広告読み込み例外: $e');
+      DebugService().log('❌ インタースティシャル広告読み込み例外: $e');
       _isAdLoaded = false;
     }
   }
@@ -183,33 +183,33 @@ class InterstitialAdService {
 
   bool shouldShowAd() {
     if (_isShowingAd) {
-      debugPrint('🔧 インタースティシャル広告表示条件チェック: 既に広告表示中');
+      DebugService().log('🔧 インタースティシャル広告表示条件チェック: 既に広告表示中');
       return false;
     }
 
     final purchaseService = OneTimePurchaseService();
     if (!purchaseService.isInitialized) {
-      debugPrint('🔧 インタースティシャル広告表示条件チェック: OneTimePurchaseServiceの初期化待機中');
+      DebugService().log('🔧 インタースティシャル広告表示条件チェック: OneTimePurchaseServiceの初期化待機中');
       return false;
     }
 
     if (purchaseService.isPremiumUnlocked) {
-      debugPrint('🔧 インタースティシャル広告表示条件チェック: プレミアムユーザー（広告非表示）');
+      DebugService().log('🔧 インタースティシャル広告表示条件チェック: プレミアムユーザー（広告非表示）');
       return false;
     }
 
     if (!_isAdLoaded || _interstitialAd == null) {
-      debugPrint('🔧 インタースティシャル広告表示条件チェック: 広告が読み込まれていない');
-      debugPrint('🔧   - _isAdLoaded: $_isAdLoaded');
-      debugPrint('🔧   - _interstitialAd: ${_interstitialAd != null}');
+      DebugService().log('🔧 インタースティシャル広告表示条件チェック: 広告が読み込まれていない');
+      DebugService().log('🔧   - _isAdLoaded: $_isAdLoaded');
+      DebugService().log('🔧   - _interstitialAd: ${_interstitialAd != null}');
       return false;
     }
 
     final shouldShow = _operationCount % _showAdEveryOperations == 0;
-    debugPrint('🔧 インタースティシャル広告表示条件チェック:');
-    debugPrint('🔧   - _operationCount: $_operationCount');
-    debugPrint('🔧   - _showAdEveryOperations: $_showAdEveryOperations');
-    debugPrint(
+    DebugService().log('🔧 インタースティシャル広告表示条件チェック:');
+    DebugService().log('🔧   - _operationCount: $_operationCount');
+    DebugService().log('🔧   - _showAdEveryOperations: $_showAdEveryOperations');
+    DebugService().log(
         '🔧   - 計算結果: $_operationCount % $_showAdEveryOperations == 0 = $shouldShow');
 
     return shouldShow;
@@ -217,18 +217,18 @@ class InterstitialAdService {
 
   Future<void> showAdIfReady() async {
     if (shouldShowAd()) {
-      debugPrint('✅ インタースティシャル広告を表示します');
+      DebugService().log('✅ インタースティシャル広告を表示します');
       try {
         _isShowingAd = true;
         await _interstitialAd!.show();
       } catch (e) {
-        debugPrint('❌ インタースティシャル広告表示失敗: $e');
+        DebugService().log('❌ インタースティシャル広告表示失敗: $e');
         _isShowingAd = false;
         _isAdLoaded = false;
         loadAd();
       }
     } else {
-      debugPrint('🔧 インタースティシャル広告表示条件を満たしていません');
+      DebugService().log('🔧 インタースティシャル広告表示条件を満たしていません');
     }
   }
 

--- a/lib/drawer/donation_screen.dart
+++ b/lib/drawer/donation_screen.dart
@@ -5,6 +5,7 @@ import 'package:in_app_purchase/in_app_purchase.dart';
 import '../services/donation_service.dart';
 import '../config.dart';
 import '../utils/dialog_utils.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 寄付・サブスクリプション移行ページのウィジェット
 /// 寄付機能とサブスクリプション移行を統合
@@ -74,8 +75,8 @@ class _DonationScreenState extends State<DonationScreen>
         // 購入状態の変更をリッスン
         _subscription = _inAppPurchase.purchaseStream.listen(
           _listenToPurchaseUpdated,
-          onDone: () => debugPrint('課金ストリームが終了しました'),
-          onError: (error) => debugPrint('課金ストリームエラー: $error'),
+          onDone: () => DebugService().log('課金ストリームが終了しました'),
+          onError: (error) => DebugService().log('課金ストリームエラー: $error'),
         );
 
         // プロダクト情報を取得
@@ -86,7 +87,7 @@ class _DonationScreenState extends State<DonationScreen>
         });
       }
     } catch (e) {
-      debugPrint('課金システム初期化エラー: $e');
+      DebugService().log('課金システム初期化エラー: $e');
       setState(() {
         _loadingMessage = '課金システムの初期化に失敗しました';
       });
@@ -104,7 +105,7 @@ class _DonationScreenState extends State<DonationScreen>
           Provider.of<DonationService>(context, listen: false);
       await donationService.initialize();
     } catch (e) {
-      debugPrint('寄付サービス初期化エラー: $e');
+      DebugService().log('寄付サービス初期化エラー: $e');
     }
   }
 
@@ -120,11 +121,11 @@ class _DonationScreenState extends State<DonationScreen>
           await _inAppPurchase.queryProductDetails(donationProductIds.toSet());
 
       if (response.notFoundIDs.isNotEmpty) {
-        debugPrint('見つからないプロダクトID: ${response.notFoundIDs}');
+        DebugService().log('見つからないプロダクトID: ${response.notFoundIDs}');
       }
 
       if (response.error != null) {
-        debugPrint('プロダクト取得エラー: ${response.error}');
+        DebugService().log('プロダクト取得エラー: ${response.error}');
         setState(() {
           _loadingMessage = '商品情報の取得に失敗しました';
         });
@@ -135,7 +136,7 @@ class _DonationScreenState extends State<DonationScreen>
         });
       }
     } catch (e) {
-      debugPrint('プロダクト取得エラー: $e');
+      DebugService().log('プロダクト取得エラー: $e');
       setState(() {
         _loadingMessage = '商品情報の取得に失敗しました';
       });
@@ -220,7 +221,7 @@ class _DonationScreenState extends State<DonationScreen>
       ),
     );
 
-    debugPrint('購入成功: ${purchaseDetails.productID}');
+    DebugService().log('購入成功: ${purchaseDetails.productID}');
   }
 
   /// 購入エラー時の処理
@@ -230,7 +231,7 @@ class _DonationScreenState extends State<DonationScreen>
       _loadingMessage = '';
     });
 
-    debugPrint('購入エラー: ${error.code} - ${error.message}');
+    DebugService().log('購入エラー: ${error.code} - ${error.message}');
 
     String errorMessage = '購入処理中にエラーが発生しました';
 
@@ -885,7 +886,7 @@ class _DonationScreenState extends State<DonationScreen>
       );
       await _inAppPurchase.buyConsumable(purchaseParam: purchaseParam);
     } catch (e) {
-      debugPrint('購入処理エラー: $e');
+      DebugService().log('購入処理エラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/drawer/settings/advanced_settings_screen.dart
+++ b/lib/drawer/settings/advanced_settings_screen.dart
@@ -5,6 +5,7 @@ import 'settings_theme.dart';
 import 'settings_persistence.dart';
 import '../../widgets/welcome_dialog.dart';
 import '../../utils/dialog_utils.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 詳細設定画面
 /// 詳細な設定項目を管理する画面
@@ -395,7 +396,7 @@ class _AdvancedSettingsScreenState extends State<AdvancedSettingsScreen> {
           ),
         ),
         onTap: () {
-          debugPrint('🔍 デバッグ: ウェルカムダイアログを表示');
+          DebugService().log('🔍 デバッグ: ウェルカムダイアログを表示');
           showConstrainedDialog(
             context: context,
             barrierDismissible: false,

--- a/lib/drawer/settings/settings_persistence.dart
+++ b/lib/drawer/settings/settings_persistence.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:convert';
+import 'package:maikago/services/debug_service.dart';
 
 /// 設定の保存・読み込み機能を管理するクラス
 /// SharedPreferencesを使用してテーマ、フォント、フォントサイズ、カスタムテーマを永続化
@@ -23,8 +24,8 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString(_themeKey, theme);
     } catch (e, stackTrace) {
-      debugPrint('❌ SettingsPersistence: テーマ保存エラー: $e');
-      debugPrint('📚 スタックトレース: $stackTrace');
+      DebugService().log('❌ SettingsPersistence: テーマ保存エラー: $e');
+      DebugService().log('📚 スタックトレース: $stackTrace');
       // iOS固有のSharedPreferencesエラー可能性
       rethrow;
     }
@@ -154,13 +155,13 @@ class SettingsPersistence {
       final key = 'budget_$tabId';
       if (budget != null) {
         await prefs.setInt(key, budget);
-        debugPrint('saveTabBudget: $tabId -> $budget (キー: $key)');
+        DebugService().log('saveTabBudget: $tabId -> $budget (キー: $key)');
       } else {
         await prefs.remove(key);
-        debugPrint('saveTabBudget: $tabId -> null (削除) (キー: $key)');
+        DebugService().log('saveTabBudget: $tabId -> null (削除) (キー: $key)');
       }
     } catch (e) {
-      debugPrint('saveTabBudget エラー: $e');
+      DebugService().log('saveTabBudget エラー: $e');
       // エラーハンドリング
     }
   }
@@ -171,10 +172,10 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       final key = 'budget_$tabId';
       final result = prefs.getInt(key);
-      debugPrint('loadTabBudget: $tabId -> $result (キー: $key)');
+      DebugService().log('loadTabBudget: $tabId -> $result (キー: $key)');
       return result;
     } catch (e) {
-      debugPrint('loadTabBudget エラー: $e');
+      DebugService().log('loadTabBudget エラー: $e');
       return null;
     }
   }
@@ -185,9 +186,9 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       final key = 'total_$tabId';
       await prefs.setInt(key, total);
-      debugPrint('saveTabTotal: $tabId -> $total (キー: $key)');
+      DebugService().log('saveTabTotal: $tabId -> $total (キー: $key)');
     } catch (e) {
-      debugPrint('saveTabTotal エラー: $e');
+      DebugService().log('saveTabTotal エラー: $e');
       // エラーハンドリング
     }
   }
@@ -198,10 +199,10 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       final key = 'total_$tabId';
       final result = prefs.getInt(key) ?? 0;
-      debugPrint('loadTabTotal: $tabId -> $result (キー: $key)');
+      DebugService().log('loadTabTotal: $tabId -> $result (キー: $key)');
       return result;
     } catch (e) {
-      debugPrint('loadTabTotal エラー: $e');
+      DebugService().log('loadTabTotal エラー: $e');
       return 0;
     }
   }
@@ -247,9 +248,9 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       const key = 'selected_tab_index';
       await prefs.setInt(key, index);
-      debugPrint('選択タブインデックス保存: $index');
+      DebugService().log('選択タブインデックス保存: $index');
     } catch (e) {
-      debugPrint('saveSelectedTabIndex エラー: $e');
+      DebugService().log('saveSelectedTabIndex エラー: $e');
     }
   }
 
@@ -259,10 +260,10 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       const key = 'selected_tab_index';
       final result = prefs.getInt(key) ?? 0;
-      debugPrint('選択タブインデックス読み込み: $result');
+      DebugService().log('選択タブインデックス読み込み: $result');
       return result;
     } catch (e) {
-      debugPrint('loadSelectedTabIndex エラー: $e');
+      DebugService().log('loadSelectedTabIndex エラー: $e');
       return 0;
     }
   }
@@ -273,9 +274,9 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       const key = 'selected_tab_id';
       await prefs.setString(key, tabId);
-      debugPrint('選択タブID保存: $tabId');
+      DebugService().log('選択タブID保存: $tabId');
     } catch (e) {
-      debugPrint('saveSelectedTabId エラー: $e');
+      DebugService().log('saveSelectedTabId エラー: $e');
     }
   }
 
@@ -285,10 +286,10 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       const key = 'selected_tab_id';
       final result = prefs.getString(key);
-      debugPrint('選択タブID読み込み: $result');
+      DebugService().log('選択タブID読み込み: $result');
       return result;
     } catch (e) {
-      debugPrint('loadSelectedTabId エラー: $e');
+      DebugService().log('loadSelectedTabId エラー: $e');
       return null;
     }
   }
@@ -298,9 +299,9 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_defaultShopDeletedKey, deleted);
-      debugPrint('デフォルトショップ削除状態保存: $deleted');
+      DebugService().log('デフォルトショップ削除状態保存: $deleted');
     } catch (e) {
-      debugPrint('saveDefaultShopDeleted エラー: $e');
+      DebugService().log('saveDefaultShopDeleted エラー: $e');
     }
   }
 
@@ -309,10 +310,10 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       final result = prefs.getBool(_defaultShopDeletedKey) ?? false;
-      debugPrint('デフォルトショップ削除状態読み込み: $result');
+      DebugService().log('デフォルトショップ削除状態読み込み: $result');
       return result;
     } catch (e) {
-      debugPrint('loadDefaultShopDeleted エラー: $e');
+      DebugService().log('loadDefaultShopDeleted エラー: $e');
       return false;
     }
   }
@@ -327,20 +328,20 @@ class SettingsPersistence {
 
       // 「二度と表示しない」がチェックされている場合は表示しない
       if (dontShowAgain) {
-        debugPrint('カメラガイドライン: 「二度と表示しない」が設定されているため非表示');
+        DebugService().log('カメラガイドライン: 「二度と表示しない」が設定されているため非表示');
         return false;
       }
 
       // 初回のみ表示
       if (hasShown) {
-        debugPrint('カメラガイドライン: 既に表示済みのため非表示');
+        DebugService().log('カメラガイドライン: 既に表示済みのため非表示');
         return false;
       }
 
-      debugPrint('カメラガイドライン: 初回表示のため表示');
+      DebugService().log('カメラガイドライン: 初回表示のため表示');
       return true;
     } catch (e) {
-      debugPrint('shouldShowCameraGuidelines エラー: $e');
+      DebugService().log('shouldShowCameraGuidelines エラー: $e');
       return true; // エラーの場合は安全のため表示
     }
   }
@@ -350,9 +351,9 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_cameraGuidelinesShownKey, true);
-      debugPrint('カメラガイドライン: 表示済みとしてマーク');
+      DebugService().log('カメラガイドライン: 表示済みとしてマーク');
     } catch (e) {
-      debugPrint('markCameraGuidelinesAsShown エラー: $e');
+      DebugService().log('markCameraGuidelinesAsShown エラー: $e');
     }
   }
 
@@ -362,9 +363,9 @@ class SettingsPersistence {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_cameraGuidelinesDontShowAgainKey, true);
       await prefs.setBool(_cameraGuidelinesShownKey, true);
-      debugPrint('カメラガイドライン: 「二度と表示しない」として設定');
+      DebugService().log('カメラガイドライン: 「二度と表示しない」として設定');
     } catch (e) {
-      debugPrint('setCameraGuidelinesDontShowAgain エラー: $e');
+      DebugService().log('setCameraGuidelinesDontShowAgain エラー: $e');
     }
   }
 
@@ -373,9 +374,9 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_autoCompleteKey, enabled);
-      debugPrint('自動購入済み設定保存: $enabled');
+      DebugService().log('自動購入済み設定保存: $enabled');
     } catch (e) {
-      debugPrint('saveAutoComplete エラー: $e');
+      DebugService().log('saveAutoComplete エラー: $e');
     }
   }
 
@@ -384,10 +385,10 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       final result = prefs.getBool(_autoCompleteKey) ?? false;
-      debugPrint('自動購入済み設定読み込み: $result');
+      DebugService().log('自動購入済み設定読み込み: $result');
       return result;
     } catch (e) {
-      debugPrint('loadAutoComplete エラー: $e');
+      DebugService().log('loadAutoComplete エラー: $e');
       return false;
     }
   }
@@ -397,9 +398,9 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_strikethroughKey, enabled);
-      debugPrint('取り消し線設定保存: $enabled');
+      DebugService().log('取り消し線設定保存: $enabled');
     } catch (e) {
-      debugPrint('saveStrikethrough エラー: $e');
+      DebugService().log('saveStrikethrough エラー: $e');
     }
   }
 
@@ -408,10 +409,10 @@ class SettingsPersistence {
     try {
       final prefs = await SharedPreferences.getInstance();
       final result = prefs.getBool(_strikethroughKey) ?? false;
-      debugPrint('取り消し線設定読み込み: $result');
+      DebugService().log('取り消し線設定読み込み: $result');
       return result;
     } catch (e) {
-      debugPrint('loadStrikethrough エラー: $e');
+      DebugService().log('loadStrikethrough エラー: $e');
       return false;
     }
   }

--- a/lib/env.dart
+++ b/lib/env.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class Env {
   static Map<String, dynamic> _config = {};
@@ -15,10 +15,10 @@ class Env {
       final String jsonString = await rootBundle.loadString('env.json');
       _config = json.decode(jsonString) as Map<String, dynamic>;
       _isInitialized = true;
-      debugPrint('✅ env.json読み込み完了');
+      DebugService().log('✅ env.json読み込み完了');
     } catch (e) {
-      debugPrint('⚠️ env.json読み込みエラー: $e');
-      debugPrint('⚠️ --dart-defineからの読み込みにフォールバックします');
+      DebugService().log('⚠️ env.json読み込みエラー: $e');
+      DebugService().log('⚠️ --dart-defineからの読み込みにフォールバックします');
       _isInitialized = true;
     }
   }
@@ -86,6 +86,6 @@ class Env {
       return '${value.substring(0, 3)}***${value.substring(value.length - 2)}';
     }
 
-    debugPrint('🔑 GOOGLE_WEB_CLIENT_ID: ${mask(googleWebClientId)}');
+    DebugService().log('🔑 GOOGLE_WEB_CLIENT_ID: ${mask(googleWebClientId)}');
   }
 }

--- a/lib/models/sort_mode.dart
+++ b/lib/models/sort_mode.dart
@@ -1,6 +1,6 @@
 // 並び替えモードと対応する比較関数
-import 'package:flutter/foundation.dart';
 import 'list.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 一覧の並び替えモード
 enum SortMode {
@@ -29,14 +29,14 @@ Comparator<ListItem> comparatorFor(SortMode mode) {
     case SortMode.qtyAsc:
       return (a, b) {
         final result = a.quantity.compareTo(b.quantity);
-        debugPrint(
+        DebugService().log(
             '🔤 ソート(個数 少ない順): ${a.name}(${a.quantity}) vs ${b.name}(${b.quantity}) = $result');
         return result;
       };
     case SortMode.qtyDesc:
       return (a, b) {
         final result = b.quantity.compareTo(a.quantity);
-        debugPrint(
+        DebugService().log(
             '🔤 ソート(個数 多い順): ${a.name}(${a.quantity}) vs ${b.name}(${b.quantity}) = $result');
         return result;
       };

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -6,6 +6,7 @@ import '../services/auth_service.dart';
 import '../services/one_time_purchase_service.dart';
 import '../services/feature_access_control.dart';
 import '../services/donation_service.dart';
+import 'package:maikago/services/debug_service.dart';
 // PaymentServiceは削除されました
 
 /// 認証状態の Provider。
@@ -33,8 +34,8 @@ class AuthProvider extends ChangeNotifier {
       _init();
     } catch (e) {
       // コンストラクタでの例外をキャッチして、ローカルモードで初期化
-      debugPrint('❌ AuthProviderコンストラクタエラー: $e');
-      debugPrint('⚠️ ローカルモードで認証を初期化します');
+      DebugService().log('❌ AuthProviderコンストラクタエラー: $e');
+      DebugService().log('⚠️ ローカルモードで認証を初期化します');
       _user = null;
       _isLoading = false;
       // 初期化完了を通知（非同期で実行）
@@ -45,7 +46,7 @@ class AuthProvider extends ChangeNotifier {
   /// 認証状態の初期化と監視登録
   Future<void> _init() async {
     try {
-      debugPrint('🔐 AuthProvider初期化開始');
+      DebugService().log('🔐 AuthProvider初期化開始');
 
       // Firebaseが初期化されているか確認
       // WebプラットフォームではFirebase.appsにアクセスするだけで例外が発生する可能性がある
@@ -56,9 +57,9 @@ class AuthProvider extends ChangeNotifier {
         // Firebase.appsにアクセスできない場合は初期化されていないと判断
         // Webプラットフォームでは特に例外が発生しやすい
         if (kIsWeb) {
-          debugPrint('⚠️ Firebase初期化確認エラー（Web）: $e。ローカルモードで動作します。');
+          DebugService().log('⚠️ Firebase初期化確認エラー（Web）: $e。ローカルモードで動作します。');
         } else {
-          debugPrint('⚠️ Firebase初期化確認エラー: $e。ローカルモードで動作します。');
+          DebugService().log('⚠️ Firebase初期化確認エラー: $e。ローカルモードで動作します。');
         }
         _user = null;
         _isLoading = false;
@@ -68,9 +69,9 @@ class AuthProvider extends ChangeNotifier {
 
       if (!isFirebaseInitialized) {
         if (kIsWeb) {
-          debugPrint('⚠️ Firebaseが初期化されていません（Web）。ローカルモードで動作します。');
+          DebugService().log('⚠️ Firebaseが初期化されていません（Web）。ローカルモードで動作します。');
         } else {
-          debugPrint('⚠️ Firebaseが初期化されていません。ローカルモードで動作します。');
+          DebugService().log('⚠️ Firebaseが初期化されていません。ローカルモードで動作します。');
         }
         _user = null;
         _isLoading = false;
@@ -81,10 +82,10 @@ class AuthProvider extends ChangeNotifier {
       // 初期ユーザー状態を設定（Firebase未初期化時はnullを返す）
       try {
         _user = _authService.currentUser;
-        debugPrint('👤 初期ユーザー: ${_user?.uid ?? "未ログイン"}');
-        debugPrint('🔐 ログイン状態: ${_user != null ? "ログイン済み" : "未ログイン"}');
+        DebugService().log('👤 初期ユーザー: ${_user?.uid ?? "未ログイン"}');
+        DebugService().log('🔐 ログイン状態: ${_user != null ? "ログイン済み" : "未ログイン"}');
       } catch (e) {
-        debugPrint('❌ 初期ユーザー取得エラー: $e');
+        DebugService().log('❌ 初期ユーザー取得エラー: $e');
         _user = null;
       }
 
@@ -100,17 +101,17 @@ class AuthProvider extends ChangeNotifier {
         }
         _featureControl.initialize(_purchaseService);
         // PaymentServiceは削除されました
-        debugPrint('✅ サービス初期化完了');
+        DebugService().log('✅ サービス初期化完了');
       } catch (e) {
-        debugPrint('❌ サービス初期化エラー: $e');
+        DebugService().log('❌ サービス初期化エラー: $e');
         // サービス初期化に失敗しても認証は継続する
       }
 
       // 認証状態の変更を監視（Firebase未初期化時はスキップ）
       try {
         _authService.authStateChanges.listen((User? user) async {
-          debugPrint('🔄 認証状態変更: ${user?.uid ?? "未ログイン"}');
-          debugPrint('🔐 ログイン状態変更: ${user != null ? "ログイン済み" : "未ログイン"}');
+          DebugService().log('🔄 認証状態変更: ${user?.uid ?? "未ログイン"}');
+          DebugService().log('🔐 ログイン状態変更: ${user != null ? "ログイン済み" : "未ログイン"}');
           _user = user;
 
           try {
@@ -125,28 +126,28 @@ class AuthProvider extends ChangeNotifier {
             }
             // PaymentServiceは削除されました
           } catch (e) {
-            debugPrint('❌ 認証状態変更時のサービス更新エラー: $e');
+            DebugService().log('❌ 認証状態変更時のサービス更新エラー: $e');
           }
 
           notifyListeners();
         }, onError: (error) {
-          debugPrint('❌ 認証状態監視エラー: $error');
+          DebugService().log('❌ 認証状態監視エラー: $error');
           // エラーが発生してもアプリは継続する
         });
       } catch (e) {
-        debugPrint('❌ 認証状態監視の設定エラー: $e');
+        DebugService().log('❌ 認証状態監視の設定エラー: $e');
         // Firebase未初期化時は監視をスキップ
       }
     } catch (e) {
-      debugPrint('❌ AuthProvider初期化エラー: $e');
+      DebugService().log('❌ AuthProvider初期化エラー: $e');
       // Firebase初期化に失敗した場合はローカルモードで動作
-      debugPrint('⚠️ ローカルモードで認証を初期化します');
+      DebugService().log('⚠️ ローカルモードで認証を初期化します');
       _user = null;
     } finally {
       // 初期化完了
       _isLoading = false;
       notifyListeners();
-      debugPrint('✅ AuthProvider初期化完了');
+      DebugService().log('✅ AuthProvider初期化完了');
     }
   }
 

--- a/lib/providers/managers/data_cache_manager.dart
+++ b/lib/providers/managers/data_cache_manager.dart
@@ -1,9 +1,9 @@
 // データの保持、キャッシュTTL管理、ローカルモード管理、データロード
 import 'dart:async';
-import 'package:flutter/foundation.dart';
 import '../../services/data_service.dart';
 import '../../models/list.dart';
 import '../../models/shop.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// データのインメモリキャッシュとロードを管理するクラス。
 /// - items/shopsの保持
@@ -44,15 +44,15 @@ class DataCacheManager {
   /// 初回/認証状態変更時のデータ読み込み（キャッシュ/TTLあり）
   /// [forceReload] が true の場合はキャッシュを無視して再読み込み
   Future<void> loadData({bool forceReload = false}) async {
-    debugPrint('=== DataCacheManager.loadData ===');
-    debugPrint(
+    DebugService().log('=== DataCacheManager.loadData ===');
+    DebugService().log(
         '現在の状態: ローカルモード=$_isLocalMode, データ読み込み済み=$_isDataLoaded');
 
     // 既にデータが読み込まれている場合はスキップ（キャッシュ最適化）
     if (!forceReload && _isDataLoaded && _items.isNotEmpty) {
       if (_lastSyncTime != null &&
           DateTime.now().difference(_lastSyncTime!).inMinutes < 5) {
-        debugPrint('データは既に読み込まれているためスキップ');
+        DebugService().log('データは既に読み込まれているためスキップ');
         return;
       }
     }
@@ -63,25 +63,25 @@ class DataCacheManager {
 
     // ローカルモードでない場合のみFirebaseから読み込み
     if (!_isLocalMode) {
-      debugPrint('Firebaseからデータを読み込み中...');
+      DebugService().log('Firebaseからデータを読み込み中...');
       await Future.wait([
         _loadItems(),
         _loadShops(),
       ]).timeout(
         const Duration(seconds: 30),
         onTimeout: () {
-          debugPrint('データ読み込みタイムアウト');
+          DebugService().log('データ読み込みタイムアウト');
           throw TimeoutException(
               'データ読み込みがタイムアウトしました', const Duration(seconds: 30));
         },
       );
     } else {
-      debugPrint('ローカルモード: Firebase読み込みをスキップ');
+      DebugService().log('ローカルモード: Firebase読み込みをスキップ');
     }
 
     _isDataLoaded = true;
     _lastSyncTime = DateTime.now();
-    debugPrint(
+    DebugService().log(
         'データ読み込み完了: アイテム${_items.length}件、ショップ${_shops.length}件');
   }
 
@@ -91,7 +91,7 @@ class DataCacheManager {
         isAnonymous: _shouldUseAnonymousSession(),
       );
     } catch (e) {
-      debugPrint('リスト読み込みエラー: $e');
+      DebugService().log('リスト読み込みエラー: $e');
       rethrow;
     }
   }
@@ -102,7 +102,7 @@ class DataCacheManager {
         isAnonymous: _shouldUseAnonymousSession(),
       );
     } catch (e) {
-      debugPrint('ショップ読み込みエラー: $e');
+      DebugService().log('ショップ読み込みエラー: $e');
       rethrow;
     }
   }

--- a/lib/providers/managers/realtime_sync_manager.dart
+++ b/lib/providers/managers/realtime_sync_manager.dart
@@ -7,6 +7,7 @@ import '../../models/shop.dart';
 import '../managers/data_cache_manager.dart';
 import '../repositories/item_repository.dart';
 import '../repositories/shop_repository.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// リアルタイム同期とバッチ更新制御を管理するクラス。
 /// - Firestore Streamの購読（items/shops）
@@ -62,28 +63,28 @@ class RealtimeSyncManager {
 
   /// リアルタイム同期の開始（items/shops を購読）
   void startRealtimeSync() {
-    debugPrint('=== _startRealtimeSync ===');
+    DebugService().log('=== _startRealtimeSync ===');
 
     // すでに購読している場合は一旦解除
     cancelRealtimeSync();
 
     // ローカルモードの場合は同期をスキップ
     if (_cacheManager.isLocalMode) {
-      debugPrint('ローカルモードのためリアルタイム同期をスキップ');
+      DebugService().log('ローカルモードのためリアルタイム同期をスキップ');
       return;
     }
 
     try {
-      debugPrint('アイテムのリアルタイム同期を開始');
+      DebugService().log('アイテムのリアルタイム同期を開始');
       _itemsSubscription = _dataService
           .getItems(isAnonymous: _shouldUseAnonymousSession())
           .listen(
         (remoteItems) {
-          debugPrint('リスト同期: ${remoteItems.length}件受信');
+          DebugService().log('リスト同期: ${remoteItems.length}件受信');
 
           // バッチ更新中はリアルタイム同期を完全に無視
           if (_isBatchUpdating) {
-            debugPrint('バッチ更新中のためリアルタイム同期をスキップ');
+            DebugService().log('バッチ更新中のためリアルタイム同期をスキップ');
             return;
           }
 
@@ -117,20 +118,20 @@ class RealtimeSyncManager {
           _notifyListeners();
         },
         onError: (error) {
-          debugPrint('リスト同期エラー: $error');
+          DebugService().log('リスト同期エラー: $error');
         },
       );
 
-      debugPrint('ショップのリアルタイム同期を開始');
+      DebugService().log('ショップのリアルタイム同期を開始');
       _shopsSubscription = _dataService
           .getShops(isAnonymous: _shouldUseAnonymousSession())
           .listen(
         (remoteShops) {
-          debugPrint('ショップ同期: ${remoteShops.length}件受信');
+          DebugService().log('ショップ同期: ${remoteShops.length}件受信');
 
           // バッチ更新中はリアルタイム同期を完全に無視
           if (_isBatchUpdating) {
-            debugPrint('バッチ更新中のためショップ同期をスキップ');
+            DebugService().log('バッチ更新中のためショップ同期をスキップ');
             return;
           }
 
@@ -164,32 +165,32 @@ class RealtimeSyncManager {
           _notifyListeners();
         },
         onError: (error) {
-          debugPrint('ショップ同期エラー: $error');
+          DebugService().log('ショップ同期エラー: $error');
         },
       );
 
-      debugPrint('リアルタイム同期開始完了');
+      DebugService().log('リアルタイム同期開始完了');
     } catch (e) {
-      debugPrint('リアルタイム同期開始エラー: $e');
+      DebugService().log('リアルタイム同期開始エラー: $e');
     }
   }
 
   /// リアルタイム同期の停止
   void cancelRealtimeSync() {
-    debugPrint('=== _cancelRealtimeSync ===');
+    DebugService().log('=== _cancelRealtimeSync ===');
 
     if (_itemsSubscription != null) {
-      debugPrint('アイテム同期を停止');
+      DebugService().log('アイテム同期を停止');
       _itemsSubscription!.cancel();
       _itemsSubscription = null;
     }
 
     if (_shopsSubscription != null) {
-      debugPrint('ショップ同期を停止');
+      DebugService().log('ショップ同期を停止');
       _shopsSubscription!.cancel();
       _shopsSubscription = null;
     }
 
-    debugPrint('リアルタイム同期停止完了');
+    DebugService().log('リアルタイム同期停止完了');
   }
 }

--- a/lib/providers/managers/shared_group_manager.dart
+++ b/lib/providers/managers/shared_group_manager.dart
@@ -4,6 +4,7 @@ import '../../services/data_service.dart';
 import '../../models/shop.dart';
 import '../managers/data_cache_manager.dart';
 import '../repositories/shop_repository.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 共有グループの管理を担うクラス。
 /// - 共有グループの作成・更新・削除
@@ -78,7 +79,7 @@ class SharedGroupManager {
 
   Future<void> updateSharedGroup(String shopId, List<String> selectedTabIds,
       {String? name, String? sharedGroupIcon}) async {
-    debugPrint('共有グループ更新: ショップID=$shopId, 選択タブ=${selectedTabIds.length}個');
+    DebugService().log('共有グループ更新: ショップID=$shopId, 選択タブ=${selectedTabIds.length}個');
 
     String? sharedGroupId;
     final currentShop =
@@ -94,7 +95,7 @@ class SharedGroupManager {
     final removedTabIds =
         previousSharedTabs.where((id) => !selectedTabIds.contains(id)).toList();
 
-    debugPrint('削除されたタブ: ${removedTabIds.length}個');
+    DebugService().log('削除されたタブ: ${removedTabIds.length}個');
 
     final updatedShop = currentShop.copyWith(
       name: name ?? currentShop.name,
@@ -106,7 +107,7 @@ class SharedGroupManager {
     );
 
     if (selectedTabIds.isEmpty) {
-      debugPrint('共有タブがすべて解除されました。タブ $shopId の共有マークを非表示にします。');
+      DebugService().log('共有タブがすべて解除されました。タブ $shopId の共有マークを非表示にします。');
     }
 
     final shopIndex =
@@ -129,7 +130,7 @@ class SharedGroupManager {
         );
         _cacheManager.shops[removedTabIndex] = updatedRemovedTab;
         _shopRepository.pendingUpdates[removedTabId] = DateTime.now();
-        debugPrint('削除されたタブ $removedTabId から現在のタブ $shopId を削除');
+        DebugService().log('削除されたタブ $removedTabId から現在のタブ $shopId を削除');
       }
     }
 
@@ -182,10 +183,10 @@ class SharedGroupManager {
         }
 
         _setSynced(true);
-        debugPrint('✅ 共有グループ更新完了');
+        DebugService().log('✅ 共有グループ更新完了');
       } catch (e) {
         _setSynced(false);
-        debugPrint('❌ 共有グループ更新エラー: $e');
+        DebugService().log('❌ 共有グループ更新エラー: $e');
         rethrow;
       }
     }
@@ -193,7 +194,7 @@ class SharedGroupManager {
 
   Future<void> removeFromSharedGroup(String shopId,
       {String? originalSharedGroupId, String? name}) async {
-    debugPrint('共有グループから削除: ショップID=$shopId');
+    DebugService().log('共有グループから削除: ショップID=$shopId');
 
     final shopIndex =
         _cacheManager.shops.indexWhere((shop) => shop.id == shopId);
@@ -256,10 +257,10 @@ class SharedGroupManager {
         }
 
         _setSynced(true);
-        debugPrint('✅ 共有グループから削除完了');
+        DebugService().log('✅ 共有グループから削除完了');
       } catch (e) {
         _setSynced(false);
-        debugPrint('❌ 共有グループ削除エラー: $e');
+        DebugService().log('❌ 共有グループ削除エラー: $e');
         rethrow;
       }
     }
@@ -267,7 +268,7 @@ class SharedGroupManager {
 
   Future<void> syncSharedGroupBudget(
       String sharedGroupId, int? newBudget) async {
-    debugPrint('共有グループ予算同期: グループID=$sharedGroupId, 予算=$newBudget');
+    DebugService().log('共有グループ予算同期: グループID=$sharedGroupId, 予算=$newBudget');
 
     final sharedShops = _cacheManager.shops
         .where((shop) => shop.sharedGroupId == sharedGroupId)
@@ -298,10 +299,10 @@ class SharedGroupManager {
         }
 
         _setSynced(true);
-        debugPrint('✅ 共有グループ予算同期完了');
+        DebugService().log('✅ 共有グループ予算同期完了');
       } catch (e) {
         _setSynced(false);
-        debugPrint('❌ 共有グループ予算同期エラー: $e');
+        DebugService().log('❌ 共有グループ予算同期エラー: $e');
         rethrow;
       }
     }

--- a/lib/providers/repositories/item_repository.dart
+++ b/lib/providers/repositories/item_repository.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import '../../services/data_service.dart';
 import '../../models/list.dart';
 import '../managers/data_cache_manager.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// アイテムのCRUD操作を管理するリポジトリ。
 /// - 楽観的更新（即座にキャッシュを更新し、バックグラウンドでFirebase保存）
@@ -33,7 +34,7 @@ class ItemRepository {
   // --- アイテム追加 ---
 
   Future<void> addItem(ListItem item) async {
-    debugPrint('🚀 リスト追加開始: ${item.name}');
+    DebugService().log('🚀 リスト追加開始: ${item.name}');
 
     // 重複チェック（IDが空の場合は新規追加として扱う）
     if (item.id.isNotEmpty) {
@@ -81,13 +82,13 @@ class ItemRepository {
           isAnonymous: _shouldUseAnonymousSession(),
         );
         _setSynced(true);
-        debugPrint('✅ アイテム追加完了: ${newItem.name}');
+        DebugService().log('✅ アイテム追加完了: ${newItem.name}');
       } else {
-        debugPrint('✅ ローカルモードでアイテム追加完了: ${newItem.name}');
+        DebugService().log('✅ ローカルモードでアイテム追加完了: ${newItem.name}');
       }
     } catch (e) {
       _setSynced(false);
-      debugPrint('❌ Firebase保存エラー: $e');
+      DebugService().log('❌ Firebase保存エラー: $e');
 
       // エラーが発生した場合は追加を取り消し
       _cacheManager.items.removeAt(0);
@@ -108,7 +109,7 @@ class ItemRepository {
   // --- アイテム更新 ---
 
   Future<void> updateItem(ListItem item) async {
-    debugPrint('リスト更新: ${item.name}');
+    DebugService().log('リスト更新: ${item.name}');
 
     // バウンス抑止のため保留中リストに追加
     pendingUpdates[item.id] = DateTime.now();
@@ -142,7 +143,7 @@ class ItemRepository {
         _setSynced(true);
       } catch (e) {
         _setSynced(false);
-        debugPrint('Firebase更新エラー: $e');
+        DebugService().log('Firebase更新エラー: $e');
 
         // エラーメッセージをユーザーに表示
         if (e.toString().contains('not-found')) {
@@ -164,7 +165,7 @@ class ItemRepository {
     List<ListItem> items, {
     required Map<String, DateTime> pendingShopUpdates,
   }) async {
-    debugPrint('バッチ更新開始: ${items.length}個のリスト');
+    DebugService().log('バッチ更新開始: ${items.length}個のリスト');
 
     // 事前に全アイテムIDを保留リストに登録（Firebase保存前）
     final now = DateTime.now();
@@ -221,7 +222,7 @@ class ItemRepository {
         _setSynced(true);
       } catch (e) {
         _setSynced(false);
-        debugPrint('Firebaseバッチ更新エラー: $e');
+        DebugService().log('Firebaseバッチ更新エラー: $e');
         rethrow;
       }
     }
@@ -230,7 +231,7 @@ class ItemRepository {
   // --- アイテム削除 ---
 
   Future<void> deleteItem(String itemId) async {
-    debugPrint('リスト削除: $itemId');
+    DebugService().log('リスト削除: $itemId');
 
     // 削除対象のアイテムを事前に取得
     final itemToDelete = _cacheManager.items.firstWhere(
@@ -264,7 +265,7 @@ class ItemRepository {
         _setSynced(true);
       } catch (e) {
         _setSynced(false);
-        debugPrint('Firebase削除エラー: $e');
+        DebugService().log('Firebase削除エラー: $e');
 
         // エラーが発生した場合は削除を取り消し
         _cacheManager.items.add(itemToDelete);
@@ -300,7 +301,7 @@ class ItemRepository {
 
   /// 複数のアイテムを一括削除（最適化版、並列バッチ）
   Future<void> deleteItems(List<String> itemIds) async {
-    debugPrint('一括削除: ${itemIds.length}件');
+    DebugService().log('一括削除: ${itemIds.length}件');
 
     // 削除対象のアイテムを事前に取得
     final itemsToDelete = <ListItem>[];
@@ -310,7 +311,7 @@ class ItemRepository {
             _cacheManager.items.firstWhere((item) => item.id == itemId);
         itemsToDelete.add(item);
       } catch (e) {
-        debugPrint('アイテムID $itemId が見つかりません: $e');
+        DebugService().log('アイテムID $itemId が見つかりません: $e');
       }
     }
 
@@ -353,7 +354,7 @@ class ItemRepository {
         _setSynced(true);
       } catch (e) {
         _setSynced(false);
-        debugPrint('Firebase一括削除エラー: $e');
+        DebugService().log('Firebase一括削除エラー: $e');
 
         // エラーが発生した場合は削除を取り消し
         _cacheManager.items.addAll(itemsToDelete);

--- a/lib/screens/camera_screen.dart
+++ b/lib/screens/camera_screen.dart
@@ -7,6 +7,7 @@ import 'package:maikago/widgets/camera_guidelines_dialog.dart';
 import 'package:maikago/drawer/settings/settings_persistence.dart';
 import 'package:maikago/utils/dialog_utils.dart';
 import 'dart:async'; // Added for Completer and Timer
+import 'package:maikago/services/debug_service.dart';
 
 class CameraScreen extends StatefulWidget {
   final Function(File image) onImageCaptured;
@@ -82,10 +83,10 @@ class _CameraScreenState extends State<CameraScreen>
     try {
       // カメラ権限をリクエスト
       final status = await Permission.camera.request();
-      debugPrint('📸 カメラ権限ステータス: $status');
+      DebugService().log('📸 カメラ権限ステータス: $status');
 
       if (status != PermissionStatus.granted) {
-        debugPrint('❌ カメラ権限が拒否されました');
+        DebugService().log('❌ カメラ権限が拒否されました');
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
@@ -102,9 +103,9 @@ class _CameraScreenState extends State<CameraScreen>
       if (_controller != null) {
         try {
           await _controller!.dispose();
-          debugPrint('✅ 既存のカメラコントローラーを解放');
+          DebugService().log('✅ 既存のカメラコントローラーを解放');
         } catch (e) {
-          debugPrint('⚠️ カメラコントローラー解放エラー: $e');
+          DebugService().log('⚠️ カメラコントローラー解放エラー: $e');
         }
         _controller = null;
       }
@@ -113,9 +114,9 @@ class _CameraScreenState extends State<CameraScreen>
       await Future.delayed(const Duration(milliseconds: 300));
 
       final cameras = await availableCameras();
-      debugPrint('📸 利用可能なカメラ数: ${cameras.length}');
+      DebugService().log('📸 利用可能なカメラ数: ${cameras.length}');
       if (cameras.isEmpty) {
-        debugPrint('❌ 利用可能なカメラが見つかりません');
+        DebugService().log('❌ 利用可能なカメラが見つかりません');
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('カメラが見つかりませんでした')),
@@ -128,7 +129,7 @@ class _CameraScreenState extends State<CameraScreen>
         (c) => c.lensDirection == CameraLensDirection.back,
         orElse: () => cameras.first,
       );
-      debugPrint('📸 選択されたカメラ: ${camera.name} (${camera.lensDirection})');
+      DebugService().log('📸 選択されたカメラ: ${camera.name} (${camera.lensDirection})');
 
       _controller = CameraController(
         camera,
@@ -139,7 +140,7 @@ class _CameraScreenState extends State<CameraScreen>
 
       // 初期化を実行
       await _controller!.initialize();
-      debugPrint('✅ カメラコントローラー初期化完了');
+      DebugService().log('✅ カメラコントローラー初期化完了');
 
       // 初期化が完了しているか確認
       if (!_controller!.value.isInitialized) {
@@ -148,7 +149,7 @@ class _CameraScreenState extends State<CameraScreen>
 
       // 初期化完了後に向きを固定
       await _controller!.lockCaptureOrientation(DeviceOrientation.portraitUp);
-      debugPrint('✅ カメラ向き固定完了');
+      DebugService().log('✅ カメラ向き固定完了');
 
       // ズーム範囲を設定
       _minZoomLevel = await _controller!.getMinZoomLevel();
@@ -160,10 +161,10 @@ class _CameraScreenState extends State<CameraScreen>
         _isInitialized = true;
         _isRequestingPermission = false;
       });
-      debugPrint('✅ カメラ初期化完了');
-      debugPrint('🔍 ズーム範囲: $_minZoomLevel - $_maxZoomLevel');
+      DebugService().log('✅ カメラ初期化完了');
+      DebugService().log('🔍 ズーム範囲: $_minZoomLevel - $_maxZoomLevel');
     } catch (e) {
-      debugPrint('❌ カメラ初期化エラー: $e');
+      DebugService().log('❌ カメラ初期化エラー: $e');
       // エラーが発生した場合、_controllerをnullにリセット
       _controller = null;
       setState(() {
@@ -180,7 +181,7 @@ class _CameraScreenState extends State<CameraScreen>
 
   Future<void> _setZoomLevel(double zoomLevel) async {
     if (_controller == null || !_isInitialized) {
-      debugPrint('❌ カメラが初期化されていません');
+      DebugService().log('❌ カメラが初期化されていません');
       return;
     }
 
@@ -190,26 +191,26 @@ class _CameraScreenState extends State<CameraScreen>
       setState(() {
         _currentZoomLevel = clampedZoom;
       });
-      debugPrint(
+      DebugService().log(
           '🔍 ズームレベル設定: $clampedZoom (範囲: $_minZoomLevel - $_maxZoomLevel)');
     } catch (e) {
-      debugPrint('❌ ズーム設定エラー: $e');
+      DebugService().log('❌ ズーム設定エラー: $e');
       // エラーが発生した場合、スライダーでズームを試す
       try {
         await _controller!.setZoomLevel(clampedZoom);
         setState(() {
           _currentZoomLevel = clampedZoom;
         });
-        debugPrint('🔍 ズームレベル再設定成功: $clampedZoom');
+        DebugService().log('🔍 ズームレベル再設定成功: $clampedZoom');
       } catch (e2) {
-        debugPrint('❌ ズーム再設定も失敗: $e2');
+        DebugService().log('❌ ズーム再設定も失敗: $e2');
       }
     }
   }
 
   Future<void> _takePicture() async {
     if (_controller == null || !_isInitialized || _isCapturing) {
-      debugPrint(
+      DebugService().log(
           '❌ 撮影条件を満たしていません: controller=${_controller != null}, initialized=$_isInitialized, capturing=$_isCapturing');
       return;
     }
@@ -218,7 +219,7 @@ class _CameraScreenState extends State<CameraScreen>
       setState(() {
         _isCapturing = true;
       });
-      debugPrint('📸 撮影開始');
+      DebugService().log('📸 撮影開始');
 
       // カメラが初期化されているか再確認
       if (!_controller!.value.isInitialized) {
@@ -232,15 +233,15 @@ class _CameraScreenState extends State<CameraScreen>
 
       // 画像を撮影（切り取りなしで全体を使用）
       final image = await _controller!.takePicture();
-      debugPrint('📸 撮影完了: ${image.path}');
+      DebugService().log('📸 撮影完了: ${image.path}');
 
       if (!mounted) return;
 
       // 撮影した画像全体を解析に使用
       widget.onImageCaptured(File(image.path));
-      debugPrint('✅ 画像全体を解析に送信');
+      DebugService().log('✅ 画像全体を解析に送信');
     } catch (e) {
-      debugPrint('❌ 撮影エラー: $e');
+      DebugService().log('❌ 撮影エラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('撮影に失敗しました: $e')),
@@ -281,12 +282,12 @@ class _CameraScreenState extends State<CameraScreen>
 
     // アプリが非アクティブになった場合、カメラを一時停止
     if (state == AppLifecycleState.inactive) {
-      debugPrint('📱 アプリが非アクティブになりました');
+      DebugService().log('📱 アプリが非アクティブになりました');
       _controller?.pausePreview();
     }
     // アプリが再アクティブになった場合、カメラを再開
     else if (state == AppLifecycleState.resumed) {
-      debugPrint('📱 アプリが再アクティブになりました');
+      DebugService().log('📱 アプリが再アクティブになりました');
       _controller?.resumePreview();
     }
   }

--- a/lib/screens/enhanced_camera_screen.dart
+++ b/lib/screens/enhanced_camera_screen.dart
@@ -7,6 +7,7 @@ import 'package:maikago/widgets/camera_guidelines_dialog.dart';
 import 'package:maikago/drawer/settings/settings_persistence.dart';
 import 'package:maikago/utils/dialog_utils.dart';
 import 'dart:async';
+import 'package:maikago/services/debug_service.dart';
 
 /// 値札撮影専用カメラ画面
 class EnhancedCameraScreen extends StatefulWidget {
@@ -87,10 +88,10 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
     try {
       // カメラ権限をリクエスト
       final status = await Permission.camera.request();
-      debugPrint('📸 カメラ権限ステータス: $status');
+      DebugService().log('📸 カメラ権限ステータス: $status');
 
       if (status != PermissionStatus.granted) {
-        debugPrint('❌ カメラ権限が拒否されました');
+        DebugService().log('❌ カメラ権限が拒否されました');
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
@@ -107,9 +108,9 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
       if (_cameraController != null) {
         try {
           await _cameraController!.dispose();
-          debugPrint('✅ 既存のカメラコントローラーを解放');
+          DebugService().log('✅ 既存のカメラコントローラーを解放');
         } catch (e) {
-          debugPrint('⚠️ カメラコントローラー解放エラー: $e');
+          DebugService().log('⚠️ カメラコントローラー解放エラー: $e');
         }
         _cameraController = null;
       }
@@ -118,9 +119,9 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
       await Future.delayed(const Duration(milliseconds: 300));
 
       final cameras = await availableCameras();
-      debugPrint('📸 利用可能なカメラ数: ${cameras.length}');
+      DebugService().log('📸 利用可能なカメラ数: ${cameras.length}');
       if (cameras.isEmpty) {
-        debugPrint('❌ 利用可能なカメラが見つかりません');
+        DebugService().log('❌ 利用可能なカメラが見つかりません');
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('カメラが見つかりませんでした')),
@@ -133,7 +134,7 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
         (c) => c.lensDirection == CameraLensDirection.back,
         orElse: () => cameras.first,
       );
-      debugPrint('📸 選択されたカメラ: ${camera.name} (${camera.lensDirection})');
+      DebugService().log('📸 選択されたカメラ: ${camera.name} (${camera.lensDirection})');
 
       _cameraController = CameraController(
         camera,
@@ -144,7 +145,7 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
 
       // 初期化を実行
       await _cameraController!.initialize();
-      debugPrint('✅ カメラコントローラー初期化完了');
+      DebugService().log('✅ カメラコントローラー初期化完了');
 
       // 初期化が完了しているか確認
       if (!_cameraController!.value.isInitialized) {
@@ -154,7 +155,7 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
       // 初期化完了後に向きを固定
       await _cameraController!
           .lockCaptureOrientation(DeviceOrientation.portraitUp);
-      debugPrint('✅ カメラ向き固定完了');
+      DebugService().log('✅ カメラ向き固定完了');
 
       // ズーム範囲を設定
       _minZoomLevel = await _cameraController!.getMinZoomLevel();
@@ -166,10 +167,10 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
         _isCameraInitialized = true;
         _isRequestingPermission = false;
       });
-      debugPrint('✅ カメラ初期化完了');
-      debugPrint('🔍 ズーム範囲: $_minZoomLevel - $_maxZoomLevel');
+      DebugService().log('✅ カメラ初期化完了');
+      DebugService().log('🔍 ズーム範囲: $_minZoomLevel - $_maxZoomLevel');
     } catch (e) {
-      debugPrint('❌ カメラ初期化エラー: $e');
+      DebugService().log('❌ カメラ初期化エラー: $e');
       _cameraController = null;
       setState(() {
         _isCameraInitialized = false;
@@ -186,7 +187,7 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
   /// ズームレベル設定
   Future<void> _setZoomLevel(double zoomLevel) async {
     if (_cameraController == null || !_isCameraInitialized) {
-      debugPrint('❌ カメラが初期化されていません');
+      DebugService().log('❌ カメラが初期化されていません');
       return;
     }
 
@@ -196,9 +197,9 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
       setState(() {
         _currentZoomLevel = clampedZoom;
       });
-      debugPrint('🔍 ズームレベル設定: $clampedZoom');
+      DebugService().log('🔍 ズームレベル設定: $clampedZoom');
     } catch (e) {
-      debugPrint('❌ ズーム設定エラー: $e');
+      DebugService().log('❌ ズーム設定エラー: $e');
     }
   }
 
@@ -219,7 +220,7 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
   /// 値札撮影
   Future<void> _takePicture() async {
     if (_cameraController == null || !_isCameraInitialized || _isCapturing) {
-      debugPrint('❌ 撮影条件を満たしていません');
+      DebugService().log('❌ 撮影条件を満たしていません');
       return;
     }
 
@@ -227,14 +228,14 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
       setState(() {
         _isCapturing = true;
       });
-      debugPrint('📸 撮影開始');
+      DebugService().log('📸 撮影開始');
 
       if (!_cameraController!.value.isInitialized) {
         throw Exception('カメラが初期化されていません');
       }
 
       final image = await _cameraController!.takePicture();
-      debugPrint('📸 撮影完了: ${image.path}');
+      DebugService().log('📸 撮影完了: ${image.path}');
 
       if (!mounted) return;
 
@@ -242,9 +243,9 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
       if (widget.onImageCaptured != null) {
         widget.onImageCaptured!(File(image.path));
       }
-      debugPrint('✅ 画像を解析に送信');
+      DebugService().log('✅ 画像を解析に送信');
     } catch (e) {
-      debugPrint('❌ 撮影エラー: $e');
+      DebugService().log('❌ 撮影エラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('撮影に失敗しました: $e')),
@@ -281,10 +282,10 @@ class _EnhancedCameraScreenState extends State<EnhancedCameraScreen>
     super.didChangeAppLifecycleState(state);
 
     if (state == AppLifecycleState.inactive) {
-      debugPrint('📱 アプリが非アクティブになりました');
+      DebugService().log('📱 アプリが非アクティブになりました');
       _cameraController?.pausePreview();
     } else if (state == AppLifecycleState.resumed) {
-      debugPrint('📱 アプリが再アクティブになりました');
+      DebugService().log('📱 アプリが再アクティブになりました');
       _cameraController?.resumePreview();
     }
   }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../services/auth_service.dart';
 import '../drawer/settings/settings_theme.dart';
 import '../utils/dialog_utils.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class LoginScreen extends StatefulWidget {
   final VoidCallback onLoginSuccess;
@@ -31,12 +32,12 @@ class _LoginScreenState extends State<LoginScreen> {
       if (!mounted) return;
 
       if (userCredential == 'success') {
-        debugPrint('✅ Googleログイン成功: コールバック実行');
+        DebugService().log('✅ Googleログイン成功: コールバック実行');
         widget.onLoginSuccess();
       } else if (userCredential == 'redirect') {
         // リダイレクト方式を使用（iOS PWA）
         // ページがリロードされるため、ローディング状態を維持
-        debugPrint('🔄 リダイレクト認証を開始しました');
+        DebugService().log('🔄 リダイレクト認証を開始しました');
         return;
       } else if (userCredential == null) {
         // ユーザーがサインインをキャンセルした場合
@@ -57,9 +58,9 @@ class _LoginScreenState extends State<LoginScreen> {
       if (!mounted) return;
 
       // デバッグ情報を出力
-      debugPrint('=== ログインエラー詳細 ===');
-      debugPrint('エラー内容: $e');
-      debugPrint('エラータイプ: ${e.runtimeType}');
+      DebugService().log('=== ログインエラー詳細 ===');
+      DebugService().log('エラー内容: $e');
+      DebugService().log('エラータイプ: ${e.runtimeType}');
 
       String errorMessage = 'ログインエラーが発生しました';
       String detailedError = '';

--- a/lib/screens/main/dialogs/sort_dialog.dart
+++ b/lib/screens/main/dialogs/sort_dialog.dart
@@ -5,6 +5,7 @@ import '../../../providers/data_provider.dart';
 import '../../../utils/dialog_utils.dart';
 import '../../../models/shop.dart';
 import '../../../models/sort_mode.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 並び替えダイアログ
 class SortDialog extends StatelessWidget {
@@ -66,7 +67,7 @@ class SortDialog extends StatelessWidget {
                         comSortMode: isIncomplete ? shop.comSortMode : mode,
                       );
 
-                      debugPrint(
+                      DebugService().log(
                           '🔧 ソートモード変更: ${isIncomplete ? "未購入" : "購入済み"} = ${mode.label}');
 
                       await dataProvider.updateShop(updatedShop);

--- a/lib/screens/main/widgets/bottom_summary_widget.dart
+++ b/lib/screens/main/widgets/bottom_summary_widget.dart
@@ -16,6 +16,7 @@ import '../../../drawer/settings/settings_persistence.dart';
 import '../../../widgets/image_analysis_progress_dialog.dart';
 import '../../enhanced_camera_screen.dart';
 import '../../../widgets/recipe_import_bottom_sheet.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// ボトムサマリーウィジェット
 /// 予算表示、合計金額表示、カメラ撮影、アイテム追加ボタンを含む
@@ -91,7 +92,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
     try {
       await _hybridOcrService.initialize();
     } catch (e) {
-      debugPrint('❌ ハイブリッドOCR初期化エラー: $e');
+      DebugService().log('❌ ハイブリッドOCR初期化エラー: $e');
     }
   }
 
@@ -204,7 +205,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
         };
       }
     } catch (e) {
-      debugPrint('❌ サマリーデータ取得エラー: $e');
+      DebugService().log('❌ サマリーデータ取得エラー: $e');
       return {
         'total': _calculateCurrentShopTotal(),
         'currentTabTotal': null,
@@ -216,7 +217,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
 
   Future<void> _onImageAnalyzePressed() async {
     try {
-      debugPrint('📷 統合カメラ画面で追加フロー開始');
+      DebugService().log('📷 統合カメラ画面で追加フロー開始');
 
       // 値札撮影カメラ画面を表示
       final result = await Navigator.of(context).push<Map<String, dynamic>>(
@@ -230,7 +231,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
       );
 
       if (result == null) {
-        debugPrint('ℹ️ カメラをキャンセルしました');
+        DebugService().log('ℹ️ カメラをキャンセルしました');
         return;
       }
 
@@ -242,7 +243,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
         await _handleImageCaptured(imageFile);
       }
     } catch (e) {
-      debugPrint('❌ カメラ処理エラー: $e');
+      DebugService().log('❌ カメラ処理エラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -267,13 +268,13 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
   /// 値札撮影結果の処理
   Future<void> _handleImageCaptured(File imageFile) async {
     try {
-      debugPrint('📸 値札画像処理開始');
+      DebugService().log('📸 値札画像処理開始');
       // 広告がWebViewレンダラーを使用しているため、OCR実行中は
       // インタースティシャル広告リソースを解放して競合を避ける
       try {
         InterstitialAdService().dispose();
       } catch (e) {
-        debugPrint('広告サービス解放エラー: $e');
+        DebugService().log('広告サービス解放エラー: $e');
       }
 
       // 改善されたローディングダイアログを表示
@@ -287,7 +288,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
       var res = await _hybridOcrService.detectItemFromImageFast(
         imageFile,
         onProgress: (step, message) {
-          debugPrint('📊 OCR進行状況(Cloud Functions): $step - $message');
+          DebugService().log('📊 OCR進行状況(Cloud Functions): $step - $message');
         },
       );
 
@@ -298,7 +299,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
       try {
         InterstitialAdService().resetSession();
       } catch (e) {
-        debugPrint('広告サービス再初期化エラー: $e');
+        DebugService().log('広告サービス再初期化エラー: $e');
       }
 
       if (res == null) {
@@ -345,9 +346,9 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
         );
       }
 
-      debugPrint('✅ 値札画像処理完了');
+      DebugService().log('✅ 値札画像処理完了');
     } catch (e) {
-      debugPrint('❌ 値札画像処理エラー: $e');
+      DebugService().log('❌ 値札画像処理エラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -35,6 +35,7 @@ import 'main/dialogs/sort_dialog.dart';
 import 'main/dialogs/item_edit_dialog.dart';
 import 'main/dialogs/tab_edit_dialog.dart';
 import 'main/widgets/bottom_summary_widget.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class MainScreen extends StatefulWidget {
   final void Function(ThemeData)? onThemeChanged;
@@ -96,7 +97,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
       }
     } catch (e) {
       // エラーが発生してもアプリの動作には影響しない
-      debugPrint('バージョン更新チェックエラー: $e');
+      DebugService().log('バージョン更新チェックエラー: $e');
     }
   }
 
@@ -423,12 +424,12 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
   /// 安全なインタースティシャル広告表示
   Future<void> _showInterstitialAdSafely() async {
     try {
-      debugPrint('🎬 安全なインタースティシャル広告表示を開始');
+      DebugService().log('🎬 安全なインタースティシャル広告表示を開始');
       InterstitialAdService().incrementOperationCount();
       await InterstitialAdService().showAdIfReady();
-      debugPrint('✅ 安全なインタースティシャル広告表示完了');
+      DebugService().log('✅ 安全なインタースティシャル広告表示完了');
     } catch (e) {
-      debugPrint('❌ インタースティシャル広告表示中にエラーが発生: $e');
+      DebugService().log('❌ インタースティシャル広告表示中にエラーが発生: $e');
       // エラーが発生してもアプリの動作を継続
     }
   }
@@ -440,7 +441,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     final dataProvider = context.read<DataProvider>();
     final shops = dataProvider.shops;
     if (shops.isEmpty) {
-      debugPrint('❌ 未購入並べ替え中断: shopsが空のため処理を停止します');
+      DebugService().log('❌ 未購入並べ替え中断: shopsが空のため処理を停止します');
       return;
     }
 
@@ -457,7 +458,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     } else {
       var safeIndex = selectedTabIndex;
       if (safeIndex < 0 || safeIndex >= shops.length) {
-        debugPrint(
+        DebugService().log(
             '⚠️ 未購入並べ替え: selectedTabIndex=$safeIndex が範囲外。shops.length=${shops.length}');
         safeIndex = safeIndex.clamp(0, shops.length - 1);
         selectedTabIndex = safeIndex;
@@ -472,7 +473,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
       incItems.sort(comparatorFor(SortMode.manual));
     }
 
-    debugPrint(
+    DebugService().log(
         '🔄 並べ替え開始: oldIndex=$oldIndex, newIndex=$newIndex, リスト長=${incItems.length}');
 
     // 範囲チェック（調整前）
@@ -480,7 +481,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
         oldIndex >= incItems.length ||
         newIndex < 0 ||
         newIndex > incItems.length) {
-      debugPrint(
+      DebugService().log(
           '❌ インデックスが範囲外: oldIndex=$oldIndex, newIndex=$newIndex, リスト長=${incItems.length}');
       return;
     }
@@ -492,12 +493,12 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
 
     // 調整後の範囲チェック
     if (newIndex < 0 || newIndex >= incItems.length) {
-      debugPrint(
+      DebugService().log(
           '❌ 調整後のnewIndexが範囲外: newIndex=$newIndex, リスト長=${incItems.length}');
       return;
     }
 
-    debugPrint('✅ 調整後: oldIndex=$oldIndex, newIndex=$newIndex');
+    DebugService().log('✅ 調整後: oldIndex=$oldIndex, newIndex=$newIndex');
 
     // 並び替え処理（リスト要素を確実に更新するため新しいリストを作成）
     final reorderedIncItems = List<ListItem>.from(incItems);
@@ -525,7 +526,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     try {
       await dataProvider.reorderItems(updatedShop, updatedIncItems);
     } catch (e) {
-      debugPrint('❌ 未購入リスト並べ替えエラー: $e');
+      DebugService().log('❌ 未購入リスト並べ替えエラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -546,7 +547,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     final dataProvider = context.read<DataProvider>();
     final shops = dataProvider.shops;
     if (shops.isEmpty) {
-      debugPrint('❌ 購入済み並べ替え中断: shopsが空のため処理を停止します');
+      DebugService().log('❌ 購入済み並べ替え中断: shopsが空のため処理を停止します');
       return;
     }
 
@@ -563,7 +564,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     } else {
       var safeIndex = selectedTabIndex;
       if (safeIndex < 0 || safeIndex >= shops.length) {
-        debugPrint(
+        DebugService().log(
             '⚠️ 購入済み並べ替え: selectedTabIndex=$safeIndex が範囲外。shops.length=${shops.length}');
         safeIndex = safeIndex.clamp(0, shops.length - 1);
         selectedTabIndex = safeIndex;
@@ -578,7 +579,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
       comItems.sort(comparatorFor(SortMode.manual));
     }
 
-    debugPrint(
+    DebugService().log(
         '🔄 購入済み並べ替え開始: oldIndex=$oldIndex, newIndex=$newIndex, リスト長=${comItems.length}');
 
     // 範囲チェック（調整前）
@@ -586,7 +587,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
         oldIndex >= comItems.length ||
         newIndex < 0 ||
         newIndex > comItems.length) {
-      debugPrint(
+      DebugService().log(
           '❌ インデックスが範囲外: oldIndex=$oldIndex, newIndex=$newIndex, リスト長=${comItems.length}');
       return;
     }
@@ -598,12 +599,12 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
 
     // 調整後の範囲チェック
     if (newIndex < 0 || newIndex >= comItems.length) {
-      debugPrint(
+      DebugService().log(
           '❌ 調整後のnewIndexが範囲外: newIndex=$newIndex, リスト長=${comItems.length}');
       return;
     }
 
-    debugPrint('✅ 調整後: oldIndex=$oldIndex, newIndex=$newIndex');
+    DebugService().log('✅ 調整後: oldIndex=$oldIndex, newIndex=$newIndex');
 
     // 並び替え処理（リスト要素を確実に更新するため新しいリストを作成）
     final reorderedComItems = List<ListItem>.from(comItems);
@@ -631,7 +632,7 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
     try {
       await dataProvider.reorderItems(updatedShop, updatedComItems);
     } catch (e) {
-      debugPrint('❌ 購入済みリスト並べ替えエラー: $e');
+      DebugService().log('❌ 購入済みリスト並べ替えエラー: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'dart:async'; // TimeoutException用
 import '../providers/data_provider.dart';
 import '../providers/auth_provider.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class SplashScreen extends StatefulWidget {
   final VoidCallback onSplashComplete;
@@ -81,7 +82,7 @@ class _SplashScreenState extends State<SplashScreen>
       await dataProvider.loadData().timeout(
         const Duration(seconds: 45),
         onTimeout: () {
-          debugPrint('スプラッシュ画面: データ読み込みタイムアウト');
+          DebugService().log('スプラッシュ画面: データ読み込みタイムアウト');
           throw TimeoutException(
               'データ読み込みがタイムアウトしました', const Duration(seconds: 45));
         },
@@ -94,7 +95,7 @@ class _SplashScreenState extends State<SplashScreen>
         _checkIfReadyToProceed();
       }
     } catch (e) {
-      debugPrint('データ読み込みエラー: $e');
+      DebugService().log('データ読み込みエラー: $e');
       // エラーが発生しても進める
       if (mounted) {
         setState(() {

--- a/lib/services/app_info_service.dart
+++ b/lib/services/app_info_service.dart
@@ -3,7 +3,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:http/http.dart' as http;
 import 'dart:convert';
 import 'dart:io' show Platform;
-import 'package:flutter/foundation.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class AppInfoService {
   static final AppInfoService _instance = AppInfoService._internal();
@@ -25,7 +25,7 @@ class AppInfoService {
       await _initPackageInfo();
       return _packageInfo!.version;
     } catch (e) {
-      debugPrint('バージョンの取得に失敗しました: $e');
+      DebugService().log('バージョンの取得に失敗しました: $e');
       // フォールバックとしてpubspec.yamlのバージョンを使用
       return '0.4.5';
     }
@@ -37,7 +37,7 @@ class AppInfoService {
       await _initPackageInfo();
       return _packageInfo!.buildNumber;
     } catch (e) {
-      debugPrint('ビルド番号の取得に失敗しました: $e');
+      DebugService().log('ビルド番号の取得に失敗しました: $e');
       // フォールバックとしてpubspec.yamlのビルド番号を使用
       return '24';
     }
@@ -73,7 +73,7 @@ class AppInfoService {
         return _isUpdateAvailable;
       }
     } catch (e) {
-      debugPrint('バージョンチェックエラー: $e');
+      DebugService().log('バージョンチェックエラー: $e');
     }
 
     return false;
@@ -128,7 +128,7 @@ class AppInfoService {
         await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
       }
     } catch (e) {
-      debugPrint('アプリストアを開けませんでした: $e');
+      DebugService().log('アプリストアを開けませんでした: $e');
     }
   }
 
@@ -141,7 +141,7 @@ class AppInfoService {
         await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
       }
     } catch (e) {
-      debugPrint('GitHubリリースページを開けませんでした: $e');
+      DebugService().log('GitHubリリースページを開けませんでした: $e');
     }
   }
 }

--- a/lib/services/camera_service.dart
+++ b/lib/services/camera_service.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 import 'package:image_picker/image_picker.dart';
-import 'package:flutter/foundation.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class CameraService {
   static final ImagePicker _picker = ImagePicker();
@@ -14,9 +14,9 @@ class CameraService {
     try {
       // Androidの場合、シャッター音を無効化する設定を追加
       if (Platform.isAndroid) {
-        debugPrint('📸 Android: シャッター音を無効化してカメラ撮影を開始');
+        DebugService().log('📸 Android: シャッター音を無効化してカメラ撮影を開始');
       } else if (Platform.isIOS) {
-        debugPrint('📸 iOS: カメラ撮影を開始');
+        DebugService().log('📸 iOS: カメラ撮影を開始');
       }
 
       final XFile? image = await _picker.pickImage(
@@ -26,14 +26,14 @@ class CameraService {
       );
 
       if (image != null) {
-        debugPrint('✅ カメラ撮影完了: ${image.path}');
+        DebugService().log('✅ カメラ撮影完了: ${image.path}');
       } else {
-        debugPrint('ℹ️ カメラ撮影をキャンセルしました');
+        DebugService().log('ℹ️ カメラ撮影をキャンセルしました');
       }
 
       return image;
     } catch (e) {
-      debugPrint('❌ カメラ撮影エラー: $e');
+      DebugService().log('❌ カメラ撮影エラー: $e');
       return null;
     }
   }

--- a/lib/services/cloud_functions_service.dart
+++ b/lib/services/cloud_functions_service.dart
@@ -1,7 +1,7 @@
 // Firebase Cloud Functions を呼び出すためのサービス
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/foundation.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// Firebase Cloud Functions を呼び出すためのサービス
 class CloudFunctionsService {
@@ -12,12 +12,12 @@ class CloudFunctionsService {
   Future<dynamic> callFunction(
       String functionName, Map<String, dynamic> data) async {
     try {
-      debugPrint('Cloud Functions呼び出し開始: $functionName');
+      DebugService().log('Cloud Functions呼び出し開始: $functionName');
 
       // 認証状態を確認
       final user = _auth.currentUser;
       if (user == null) {
-        debugPrint('ユーザーが認証されていません');
+        DebugService().log('ユーザーが認証されていません');
         throw Exception('ユーザーが認証されていません');
       }
 
@@ -25,10 +25,10 @@ class CloudFunctionsService {
       final callable = _functions.httpsCallable(functionName);
       final result = await callable.call(data);
 
-      debugPrint('Cloud Functions呼び出し成功: $functionName');
+      DebugService().log('Cloud Functions呼び出し成功: $functionName');
       return result.data;
     } catch (e) {
-      debugPrint('Cloud Functions呼び出しエラー: $functionName - $e');
+      DebugService().log('Cloud Functions呼び出しエラー: $functionName - $e');
       rethrow;
     }
   }
@@ -36,20 +36,20 @@ class CloudFunctionsService {
   /// 画像解析用のCloud Functionsを呼び出す
   Future<Map<String, dynamic>> analyzeImage(String imageUrl) async {
     try {
-      debugPrint('画像解析開始');
+      DebugService().log('画像解析開始');
       final preview =
           imageUrl.length > 50 ? imageUrl.substring(0, 50) : imageUrl;
-      debugPrint(
+      DebugService().log(
           '送信データ: hasImageUrl=${imageUrl.isNotEmpty}, imageUrlLength=${imageUrl.length}, imageUrlPreview=$preview...');
 
       final result = await callFunction('analyzeImage', {
         'imageUrl': imageUrl,
         'timestamp': DateTime.now().toIso8601String(),
       });
-      debugPrint('画像解析完了');
+      DebugService().log('画像解析完了');
       return result as Map<String, dynamic>;
     } catch (e) {
-      debugPrint('画像解析エラー: $e');
+      DebugService().log('画像解析エラー: $e');
       rethrow;
     }
   }
@@ -57,16 +57,16 @@ class CloudFunctionsService {
   /// 商品情報取得用のCloud Functionsを呼び出す
   Future<Map<String, dynamic>> getProductInfo(String productId) async {
     try {
-      debugPrint('商品情報取得開始: $productId');
+      DebugService().log('商品情報取得開始: $productId');
 
       final result = await callFunction('getProductInfo', {
         'productId': productId,
       });
 
-      debugPrint('商品情報取得完了');
+      DebugService().log('商品情報取得完了');
       return result as Map<String, dynamic>;
     } catch (e) {
-      debugPrint('商品情報取得エラー: $e');
+      DebugService().log('商品情報取得エラー: $e');
       rethrow;
     }
   }
@@ -74,17 +74,17 @@ class CloudFunctionsService {
   /// データ同期用のCloud Functionsを呼び出す
   Future<Map<String, dynamic>> syncData(Map<String, dynamic> syncData) async {
     try {
-      debugPrint('データ同期開始');
+      DebugService().log('データ同期開始');
 
       final result = await callFunction('syncData', {
         'syncData': syncData,
         'timestamp': DateTime.now().toIso8601String(),
       });
 
-      debugPrint('データ同期完了');
+      DebugService().log('データ同期完了');
       return result as Map<String, dynamic>;
     } catch (e) {
-      debugPrint('データ同期エラー: $e');
+      DebugService().log('データ同期エラー: $e');
       rethrow;
     }
   }

--- a/lib/services/data_service.dart
+++ b/lib/services/data_service.dart
@@ -2,12 +2,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter/foundation.dart';
 import 'dart:async'; // TimeoutException用
 import 'package:firebase_core/firebase_core.dart';
 import 'package:uuid/uuid.dart';
 import '../models/list.dart';
 import '../models/shop.dart';
+import 'package:maikago/services/debug_service.dart';
 // debugPrintを追加
 
 /// データアクセス層。
@@ -28,7 +28,7 @@ class DataService {
       // FirebaseCoreが初期化済みかを確認
       return Firebase.apps.isNotEmpty;
     } catch (e) {
-      debugPrint('Firebase利用不可: $e');
+      DebugService().log('Firebase利用不可: $e');
       return false;
     }
   }
@@ -41,7 +41,7 @@ class DataService {
       await _firestore.waitForPendingWrites().timeout(timeout);
       return true;
     } catch (e) {
-      debugPrint('Firebase接続タイムアウトまたはエラー: $e');
+      DebugService().log('Firebase接続タイムアウトまたはエラー: $e');
       return false;
     }
   }
@@ -98,7 +98,7 @@ class DataService {
   Future<void> saveItem(ListItem item, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためリスト保存をスキップ');
+      DebugService().log('Firebase利用不可のためリスト保存をスキップ');
       return;
     }
 
@@ -123,7 +123,7 @@ class DataService {
   Future<void> updateItem(ListItem item, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためリスト更新をスキップ');
+      DebugService().log('Firebase利用不可のためリスト更新をスキップ');
       return;
     }
 
@@ -174,7 +174,7 @@ class DataService {
   Future<void> deleteItem(String itemId, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためリスト削除をスキップ');
+      DebugService().log('Firebase利用不可のためリスト削除をスキップ');
       return;
     }
 
@@ -205,7 +205,7 @@ class DataService {
   Stream<List<ListItem>> getItems({bool isAnonymous = false}) {
     // Firebaseが利用できない場合は空のストリームを返す
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためリスト取得をスキップ');
+      DebugService().log('Firebase利用不可のためリスト取得をスキップ');
       return Stream.value([]);
     }
 
@@ -241,7 +241,7 @@ class DataService {
   Future<List<ListItem>> getItemsOnce({bool isAnonymous = false}) async {
     // Firebaseが利用できない場合は空のリストを返す
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためリスト取得をスキップ');
+      DebugService().log('Firebase利用不可のためリスト取得をスキップ');
       return [];
     }
 
@@ -249,7 +249,7 @@ class DataService {
       // Firebase接続をチェック（タイムアウト付き）
       final isConnected = await _isFirebaseConnected();
       if (!isConnected) {
-        debugPrint('Firebase接続不可のためアイテム取得をスキップ');
+        DebugService().log('Firebase接続不可のためアイテム取得をスキップ');
         return [];
       }
 
@@ -265,7 +265,7 @@ class DataService {
       final snapshot = await collection.get().timeout(
         const Duration(seconds: 10),
         onTimeout: () {
-          debugPrint('リスト取得タイムアウト');
+          DebugService().log('リスト取得タイムアウト');
           throw TimeoutException(
               'アイテム取得がタイムアウトしました', const Duration(seconds: 10));
         },
@@ -294,10 +294,10 @@ class DataService {
       }
 
       final items = uniqueItemsMap.values.toList();
-      debugPrint('リスト取得完了: ${items.length}件');
+      DebugService().log('リスト取得完了: ${items.length}件');
       return items;
     } catch (e) {
-      debugPrint('リスト取得エラー: $e');
+      DebugService().log('リスト取得エラー: $e');
       // エラーが発生しても空のリストを返してアプリを継続
       return [];
     }
@@ -307,7 +307,7 @@ class DataService {
   Future<void> saveShop(Shop shop, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためショップ保存をスキップ');
+      DebugService().log('Firebase利用不可のためショップ保存をスキップ');
       return;
     }
 
@@ -332,7 +332,7 @@ class DataService {
   Future<void> updateShop(Shop shop, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためショップ更新をスキップ');
+      DebugService().log('Firebase利用不可のためショップ更新をスキップ');
       return;
     }
 
@@ -392,7 +392,7 @@ class DataService {
   Future<void> deleteShop(String shopId, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためショップ削除をスキップ');
+      DebugService().log('Firebase利用不可のためショップ削除をスキップ');
       return;
     }
 
@@ -443,7 +443,7 @@ class DataService {
                   }
                 }
               } catch (e) {
-                debugPrint('共有データ更新エラー（transmission指定）: $e');
+                DebugService().log('共有データ更新エラー（transmission指定）: $e');
               }
             } else {
               // fallback: contentId に紐づく transmissions を検索して更新
@@ -477,7 +477,7 @@ class DataService {
             }
           }
         } catch (e) {
-          debugPrint('共有データ更新エラー（ショップ削除前）: $e');
+          DebugService().log('共有データ更新エラー（ショップ削除前）: $e');
         }
 
         // マーカーを追加して、自動追加ロジックによる復元を防止
@@ -488,7 +488,7 @@ class DataService {
             });
           }
         } catch (e) {
-          debugPrint('削除マーカー追加エラー: $e');
+          DebugService().log('削除マーカー追加エラー: $e');
         }
 
         // 共有データの更新後にユーザーのショップを削除
@@ -509,7 +509,7 @@ class DataService {
   Stream<List<Shop>> getShops({bool isAnonymous = false}) {
     // Firebaseが利用できない場合は空のストリームを返す
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためショップ取得をスキップ');
+      DebugService().log('Firebase利用不可のためショップ取得をスキップ');
       return Stream.value([]);
     }
 
@@ -544,7 +544,7 @@ class DataService {
   Future<List<Shop>> getShopsOnce({bool isAnonymous = false}) async {
     // Firebaseが利用できない場合は空のリストを返す
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためショップ取得をスキップ');
+      DebugService().log('Firebase利用不可のためショップ取得をスキップ');
       return [];
     }
 
@@ -552,7 +552,7 @@ class DataService {
       // Firebase接続をチェック（タイムアウト付き）
       final isConnected = await _isFirebaseConnected();
       if (!isConnected) {
-        debugPrint('Firebase接続不可のためショップ取得をスキップ');
+        DebugService().log('Firebase接続不可のためショップ取得をスキップ');
         return [];
       }
 
@@ -568,7 +568,7 @@ class DataService {
       final snapshot = await collection.get().timeout(
         const Duration(seconds: 10),
         onTimeout: () {
-          debugPrint('ショップ取得タイムアウト');
+          DebugService().log('ショップ取得タイムアウト');
           throw TimeoutException(
               'ショップ取得がタイムアウトしました', const Duration(seconds: 10));
         },
@@ -597,10 +597,10 @@ class DataService {
       }
 
       final shops = uniqueShopsMap.values.toList();
-      debugPrint('ショップ取得完了: ${shops.length}件');
+      DebugService().log('ショップ取得完了: ${shops.length}件');
       return shops;
     } catch (e) {
-      debugPrint('ショップ取得エラー: $e');
+      DebugService().log('ショップ取得エラー: $e');
       // エラーが発生しても空のリストを返してアプリを継続
       return [];
     }
@@ -610,7 +610,7 @@ class DataService {
   Future<void> saveUserProfile(Map<String, dynamic> profile) async {
     // Firebaseが利用できない場合はスキップ
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためプロフィール保存をスキップ');
+      DebugService().log('Firebase利用不可のためプロフィール保存をスキップ');
       return;
     }
 
@@ -631,7 +631,7 @@ class DataService {
   Future<Map<String, dynamic>?> getUserProfile() async {
     // Firebaseが利用できない場合はnullを返す
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のためプロフィール取得をスキップ');
+      DebugService().log('Firebase利用不可のためプロフィール取得をスキップ');
       return null;
     }
 
@@ -650,7 +650,7 @@ class DataService {
   Future<bool> isDataSynced() async {
     // Firebaseが利用できない場合はfalseを返す
     if (!_isFirebaseAvailable) {
-      debugPrint('Firebase利用不可のため同期状態チェックをスキップ');
+      DebugService().log('Firebase利用不可のため同期状態チェックをスキップ');
       return false;
     }
 

--- a/lib/services/debug_service.dart
+++ b/lib/services/debug_service.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import '../config.dart';
 
 /// デバッグ機能を提供するサービス
-/// 開発時のみ有効で、本番環境では無効化される
+/// kDebugModeガードにより、リリースビルドではログ出力と文字列生成を抑制
 class DebugService extends ChangeNotifier {
   static final DebugService _instance = DebugService._internal();
   factory DebugService() => _instance;
@@ -18,30 +18,37 @@ class DebugService extends ChangeNotifier {
   bool get isProfileMode => kProfileMode;
 
   /// 製品版リリース用のデバッグログ制御
-  /// 本番環境では常にfalseを返す
   /// 環境変数とFlutterのkDebugModeの両方を考慮
   bool get enableDebugMode =>
       isDebugMode &&
       !isProductionMode &&
-      configEnableDebugMode; // config.dartの環境変数設定も考慮
+      configEnableDebugMode;
 
-  /// デバッグ情報を出力（製品版では無効化）
+  /// 一般的なログ出力（デバッグモードのみ）
+  /// 全debugPrint呼び出しの統一的な置き換え先
+  void log(String message) {
+    if (kDebugMode) {
+      debugPrint(message);
+    }
+  }
+
+  /// デバッグ情報を出力（デバッグモードのみ）
   void logDebug(String message) {
-    if (enableDebugMode) {
+    if (kDebugMode) {
       debugPrint('🔍 DEBUG: $message');
     }
   }
 
-  /// 警告情報を出力（製品版では無効化）
+  /// 警告情報を出力（デバッグモードのみ）
   void logWarning(String message) {
-    if (enableDebugMode) {
+    if (kDebugMode) {
       debugPrint('⚠️ WARNING: $message');
     }
   }
 
-  /// エラー情報を出力（製品版では無効化）
+  /// エラー情報を出力（デバッグモードのみ）
   void logError(String message, [dynamic error, StackTrace? stackTrace]) {
-    if (enableDebugMode) {
+    if (kDebugMode) {
       debugPrint('❌ ERROR: $message');
       if (error != null) {
         debugPrint('エラー詳細: $error');
@@ -52,24 +59,16 @@ class DebugService extends ChangeNotifier {
     }
   }
 
-  /// パフォーマンス情報を出力（製品版では無効化）
+  /// パフォーマンス情報を出力（デバッグモードのみ）
   void logPerformance(String operation, Duration duration) {
-    if (enableDebugMode) {
+    if (kDebugMode) {
       debugPrint('⚡ PERFORMANCE: $operation took ${duration.inMilliseconds}ms');
-    }
-  }
-
-  /// 一般的なデバッグログ出力（製品版では無効化）
-  /// 既存のdebugPrint呼び出しを置き換えるためのメソッド
-  void log(String message) {
-    if (enableDebugMode) {
-      debugPrint(message);
     }
   }
 
   /// 条件付きデバッグログ出力
   void logIf(bool condition, String message) {
-    if (condition && enableDebugMode) {
+    if (condition && kDebugMode) {
       debugPrint(message);
     }
   }
@@ -87,20 +86,4 @@ class DebugService extends ChangeNotifier {
 
   /// デバッグ機能が利用可能かどうか
   bool get isDebugEnabled => enableDebugMode;
-
-  /// デバッグ機能を無効化（本番環境用）
-  void disableDebug() {
-    // 本番環境では何もしない
-    if (isProductionMode) {
-      return;
-    }
-  }
-
-  /// デバッグ機能を有効化（開発環境用）
-  void enableDebug() {
-    // 開発環境では何もしない（デフォルトで有効）
-    if (isDebugMode) {
-      return;
-    }
-  }
 }

--- a/lib/services/donation_service.dart
+++ b/lib/services/donation_service.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import '../models/donation.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 寄付機能を管理するサービス
 class DonationService extends ChangeNotifier {
@@ -59,12 +60,12 @@ class DonationService extends ChangeNotifier {
   /// 初期化
   Future<void> initialize() async {
     if (_isInitialized) {
-      debugPrint('寄付サービスは既に初期化済みです。');
+      DebugService().log('寄付サービスは既に初期化済みです。');
       return;
     }
 
     try {
-      debugPrint('寄付サービス初期化開始');
+      DebugService().log('寄付サービス初期化開始');
 
       // 現在のユーザーIDを取得して設定
       final user = _auth.currentUser;
@@ -73,9 +74,9 @@ class DonationService extends ChangeNotifier {
       await _loadFromLocalStorage();
       await _loadFromFirestore();
       _isInitialized = true;
-      debugPrint('寄付サービス初期化完了');
+      DebugService().log('寄付サービス初期化完了');
     } catch (e) {
-      debugPrint('寄付サービス初期化エラー: $e');
+      DebugService().log('寄付サービス初期化エラー: $e');
       _setError('初期化に失敗しました: $e');
     }
   }
@@ -101,7 +102,7 @@ class DonationService extends ChangeNotifier {
     _saveToFirestore();
     notifyListeners();
 
-    debugPrint('寄付を追加しました: ¥$amount (${donation.id})');
+    DebugService().log('寄付を追加しました: ¥$amount (${donation.id})');
   }
 
   /// 寄付履歴をクリア（デバッグ用）
@@ -111,7 +112,7 @@ class DonationService extends ChangeNotifier {
     _saveToFirestore();
     notifyListeners();
 
-    debugPrint('寄付履歴をクリアしました');
+    DebugService().log('寄付履歴をクリアしました');
   }
 
   /// 特定の寄付を削除（デバッグ用）
@@ -121,7 +122,7 @@ class DonationService extends ChangeNotifier {
     _saveToFirestore();
     notifyListeners();
 
-    debugPrint('寄付を削除しました: $donationId');
+    DebugService().log('寄付を削除しました: $donationId');
   }
 
   /// ローカルストレージから読み込み
@@ -137,7 +138,7 @@ class DonationService extends ChangeNotifier {
                   Map<String, dynamic>.from({'data': jsonString})
                       .map((key, value) => MapEntry(key, value))));
             } catch (e) {
-              debugPrint('寄付データのJSONパースエラー: $e');
+              DebugService().log('寄付データのJSONパースエラー: $e');
               return null;
             }
           })
@@ -145,9 +146,9 @@ class DonationService extends ChangeNotifier {
           .cast<Donation>()
           .toList();
 
-      debugPrint('寄付データをローカルストレージから読み込み完了: ${_donations.length}件');
+      DebugService().log('寄付データをローカルストレージから読み込み完了: ${_donations.length}件');
     } catch (e) {
-      debugPrint('寄付データローカルストレージ読み込みエラー: $e');
+      DebugService().log('寄付データローカルストレージ読み込みエラー: $e');
     }
   }
 
@@ -161,9 +162,9 @@ class DonationService extends ChangeNotifier {
           .toList();
       await prefs.setStringList('donations', donationsJson);
 
-      debugPrint('寄付データをローカルストレージに保存完了: ${_donations.length}件');
+      DebugService().log('寄付データをローカルストレージに保存完了: ${_donations.length}件');
     } catch (e) {
-      debugPrint('寄付データローカルストレージ保存エラー: $e');
+      DebugService().log('寄付データローカルストレージ保存エラー: $e');
     }
   }
 
@@ -194,13 +195,13 @@ class DonationService extends ChangeNotifier {
         // Firestoreのデータを優先し、重複を避けるためにマージ
         _mergeDonations(firestoreDonations);
 
-        debugPrint(
+        DebugService().log(
             '寄付データをFirestoreから読み込み完了: ${_donations.length}件 (ユーザー: $user.uid)');
       } else {
-        debugPrint('寄付データなし (ユーザー: $user.uid)');
+        DebugService().log('寄付データなし (ユーザー: $user.uid)');
       }
     } catch (e) {
-      debugPrint('寄付データFirestore読み込みエラー: $e');
+      DebugService().log('寄付データFirestore読み込みエラー: $e');
     }
   }
 
@@ -225,9 +226,9 @@ class DonationService extends ChangeNotifier {
         'updatedAt': FieldValue.serverTimestamp(),
       });
 
-      debugPrint('寄付データをFirestoreに保存完了 (ユーザー: $user.uid)');
+      DebugService().log('寄付データをFirestoreに保存完了 (ユーザー: $user.uid)');
     } catch (e) {
-      debugPrint('寄付データFirestore保存エラー: $e');
+      DebugService().log('寄付データFirestore保存エラー: $e');
     }
   }
 
@@ -258,11 +259,11 @@ class DonationService extends ChangeNotifier {
 
   /// アカウント切り替え時の処理
   void handleAccountSwitch(String newUserId) {
-    debugPrint('アカウント切り替え検知: $_currentUserId → $newUserId');
+    DebugService().log('アカウント切り替え検知: $_currentUserId → $newUserId');
 
     // ユーザーIDが変更された場合のみ処理を実行
     if (_currentUserId != newUserId) {
-      debugPrint('アカウントが変更されました。寄付データをリセットします。');
+      DebugService().log('アカウントが変更されました。寄付データをリセットします。');
 
       // 状態をリセット
       _donations.clear();
@@ -275,9 +276,9 @@ class DonationService extends ChangeNotifier {
       }
 
       notifyListeners();
-      debugPrint('寄付データのリセット完了。新ユーザーID: $newUserId');
+      DebugService().log('寄付データのリセット完了。新ユーザーID: $newUserId');
     } else {
-      debugPrint('同じユーザーIDのため、寄付データの変更は不要です。');
+      DebugService().log('同じユーザーIDのため、寄付データの変更は不要です。');
     }
   }
 

--- a/lib/services/hybrid_ocr_service.dart
+++ b/lib/services/hybrid_ocr_service.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 import 'package:crypto/crypto.dart';
-import 'package:flutter/foundation.dart';
 import 'package:maikago/config.dart';
 import 'package:maikago/services/vision_ocr_service.dart';
+import 'package:maikago/services/debug_service.dart';
 
 class HybridOcrService {
   final VisionOcrService _visionService = VisionOcrService();
@@ -13,9 +13,9 @@ class HybridOcrService {
 
   /// Vision API専用OCRサービスの初期化
   Future<void> initialize() async {
-    debugPrint('🚀 Cloud Functions OCRサービス初期化開始');
-    debugPrint('📸 Cloud Functions経由のVision API + ChatGPT解析システム');
-    debugPrint('🎯 Cloud Functions OCRサービス初期化完了');
+    DebugService().log('🚀 Cloud Functions OCRサービス初期化開始');
+    DebugService().log('📸 Cloud Functions経由のVision API + ChatGPT解析システム');
+    DebugService().log('🎯 Cloud Functions OCRサービス初期化完了');
   }
 
   /// 画像のハッシュ値を計算
@@ -30,13 +30,13 @@ class HybridOcrService {
       {OcrProgressCallback? onProgress}) async {
     try {
       onProgress?.call(OcrProgressStep.initializing, 'OCR解析を初期化中...');
-      debugPrint('🔍 Cloud Functions OCR解析開始');
+      DebugService().log('🔍 Cloud Functions OCR解析開始');
 
       // キャッシュチェック
       final imageHash = _calculateImageHash(image);
       if (_cache.containsKey(imageHash)) {
         onProgress?.call(OcrProgressStep.completed, 'キャッシュから結果を取得');
-        debugPrint('⚡ キャッシュから結果を取得');
+        DebugService().log('⚡ キャッシュから結果を取得');
         return _cache[imageHash];
       }
 
@@ -48,24 +48,24 @@ class HybridOcrService {
           .timeout(
         const Duration(seconds: cloudFunctionsTimeoutSeconds),
         onTimeout: () {
-          debugPrint('⏰ Cloud Functionsタイムアウト');
+          DebugService().log('⏰ Cloud Functionsタイムアウト');
           return null;
         },
       );
 
       if (result != null) {
         onProgress?.call(OcrProgressStep.completed, 'Cloud Functionsで解析完了');
-        debugPrint('✅ Cloud Functionsで商品情報を採用: ${result.name} ¥${result.price}');
+        DebugService().log('✅ Cloud Functionsで商品情報を採用: ${result.name} ¥${result.price}');
         _addToCache(imageHash, result);
         return result;
       }
 
       onProgress?.call(OcrProgressStep.failed, '解析に失敗しました');
-      debugPrint('❌ OCR解析に失敗しました');
+      DebugService().log('❌ OCR解析に失敗しました');
       return null;
     } catch (e) {
       onProgress?.call(OcrProgressStep.failed, 'エラーが発生しました');
-      debugPrint('❌ OCR解析エラー: $e');
+      DebugService().log('❌ OCR解析エラー: $e');
       return null;
     }
   }
@@ -84,17 +84,17 @@ class HybridOcrService {
       // 最も古いエントリを削除（簡易的なLRU）
       final oldestKey = _cache.keys.first;
       _cache.remove(oldestKey);
-      debugPrint('🗑️ 古いキャッシュエントリを削除: $oldestKey');
+      DebugService().log('🗑️ 古いキャッシュエントリを削除: $oldestKey');
     }
 
     _cache[imageHash] = result;
-    debugPrint('💾 結果をキャッシュに保存: $imageHash');
+    DebugService().log('💾 結果をキャッシュに保存: $imageHash');
   }
 
   /// キャッシュをクリア
   void clearCache() {
     _cache.clear();
-    debugPrint('🗑️ OCRキャッシュをクリアしました');
+    DebugService().log('🗑️ OCRキャッシュをクリアしました');
   }
 
   /// キャッシュ統計を取得
@@ -108,6 +108,6 @@ class HybridOcrService {
 
   void dispose() {
     clearCache();
-    debugPrint('🗑️ Cloud Functions OCRサービスリソースを解放しました');
+    DebugService().log('🗑️ Cloud Functions OCRサービスリソースを解放しました');
   }
 }

--- a/lib/services/item_service.dart
+++ b/lib/services/item_service.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 
 import 'data_service.dart';
 import '../models/list.dart';
 import '../models/shop.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// アイテム（商品）のCRUD操作を担当するサービス
 ///
@@ -32,9 +32,9 @@ class ItemService {
   Future<void> saveItem(ListItem item, {required bool isAnonymous}) async {
     try {
       await _dataService.saveItem(item, isAnonymous: isAnonymous);
-      debugPrint('✅ アイテム保存完了: ${item.name}');
+      DebugService().log('✅ アイテム保存完了: ${item.name}');
     } catch (e) {
-      debugPrint('❌ Firebase保存エラー: $e');
+      DebugService().log('❌ Firebase保存エラー: $e');
       rethrow;
     }
   }
@@ -44,7 +44,7 @@ class ItemService {
     try {
       await _dataService.updateItem(item, isAnonymous: isAnonymous);
     } catch (e) {
-      debugPrint('Firebase更新エラー: $e');
+      DebugService().log('Firebase更新エラー: $e');
       _throwUserFriendlyError(e, 'アイテムの更新');
     }
   }
@@ -65,9 +65,9 @@ class ItemService {
               )),
         );
       }
-      debugPrint('✅ バッチ更新完了: ${items.length}個のアイテム');
+      DebugService().log('✅ バッチ更新完了: ${items.length}個のアイテム');
     } catch (e) {
-      debugPrint('Firebaseバッチ更新エラー: $e');
+      DebugService().log('Firebaseバッチ更新エラー: $e');
       rethrow;
     }
   }
@@ -77,7 +77,7 @@ class ItemService {
     try {
       await _dataService.deleteItem(itemId, isAnonymous: isAnonymous);
     } catch (e) {
-      debugPrint('Firebase削除エラー: $e');
+      DebugService().log('Firebase削除エラー: $e');
       _throwUserFriendlyError(e, 'アイテムの削除');
     }
   }
@@ -100,9 +100,9 @@ class ItemService {
           ),
         );
       }
-      debugPrint('✅ 一括削除完了: ${itemIds.length}件');
+      DebugService().log('✅ 一括削除完了: ${itemIds.length}件');
     } catch (e) {
-      debugPrint('Firebase一括削除エラー: $e');
+      DebugService().log('Firebase一括削除エラー: $e');
       _throwUserFriendlyError(e, 'アイテムの削除');
     }
   }

--- a/lib/services/product_name_summarizer_service.dart
+++ b/lib/services/product_name_summarizer_service.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_functions/cloud_functions.dart';
-import 'package:flutter/foundation.dart';
 import 'package:maikago/config.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 商品名を簡潔に要約するサービス
 /// Cloud Functions経由でGPT-4o-miniを使用してメーカー、商品名、重さなどの基本情報のみを抽出
@@ -10,20 +10,20 @@ class ProductNameSummarizerService {
     // リトライ機能付きでAPI呼び出し
     for (int attempt = 1; attempt <= chatGptMaxRetries; attempt++) {
       try {
-        debugPrint('🤖 商品名要約API呼び出し試行 $attempt/$chatGptMaxRetries');
+        DebugService().log('🤖 商品名要約API呼び出し試行 $attempt/$chatGptMaxRetries');
         final result = await _callCloudFunction(originalName);
         if (result.isNotEmpty) {
-          debugPrint('✅ 商品名要約API呼び出し成功（試行 $attempt）');
+          DebugService().log('✅ 商品名要約API呼び出し成功（試行 $attempt）');
           return result;
         }
       } catch (e) {
-        debugPrint('❌ 商品名要約API呼び出し失敗（試行 $attempt）: $e');
+        DebugService().log('❌ 商品名要約API呼び出し失敗（試行 $attempt）: $e');
         if (attempt < chatGptMaxRetries) {
           final waitTime = attempt * 2;
-          debugPrint('⏳ $waitTime秒後に再試行します...');
+          DebugService().log('⏳ $waitTime秒後に再試行します...');
           await Future.delayed(Duration(seconds: waitTime));
         } else {
-          debugPrint('❌ 最大リトライ回数（$chatGptMaxRetries）に達しました');
+          DebugService().log('❌ 最大リトライ回数（$chatGptMaxRetries）に達しました');
         }
       }
     }
@@ -34,7 +34,7 @@ class ProductNameSummarizerService {
   /// Cloud Functions呼び出しの実装（商品名要約）
   static Future<String> _callCloudFunction(String originalName) async {
     try {
-      debugPrint('🤖 商品名要約開始（Cloud Functions経由）: ${originalName.length}文字');
+      DebugService().log('🤖 商品名要約開始（Cloud Functions経由）: ${originalName.length}文字');
 
       final callable =
           FirebaseFunctions.instance.httpsCallable('summarizeProductName');
@@ -47,24 +47,24 @@ class ProductNameSummarizerService {
       if (data['success'] == true) {
         final summarizedName = data['summarizedName'] as String? ?? '';
         if (summarizedName.isNotEmpty) {
-          debugPrint('✅ 商品名要約完了: $summarizedName');
+          DebugService().log('✅ 商品名要約完了: $summarizedName');
           return summarizedName;
         }
       }
 
       return _fallbackSummarize(originalName);
     } on FirebaseFunctionsException catch (e) {
-      debugPrint('❌ 商品名要約Cloud Functionsエラー: [${e.code}] ${e.message}');
+      DebugService().log('❌ 商品名要約Cloud Functionsエラー: [${e.code}] ${e.message}');
       return _fallbackSummarize(originalName);
     } catch (e) {
-      debugPrint('❌ 商品名要約例外: $e');
+      DebugService().log('❌ 商品名要約例外: $e');
       return _fallbackSummarize(originalName);
     }
   }
 
   /// APIが利用できない場合のフォールバック要約
   static String _fallbackSummarize(String originalName) {
-    debugPrint('🔄 フォールバック要約を使用');
+    DebugService().log('🔄 フォールバック要約を使用');
 
     // 不要なキーワードを除外するパターン
     final excludePatterns = [
@@ -112,7 +112,7 @@ class ProductNameSummarizerService {
     }
 
     final summarized = result.join(' ');
-    debugPrint('📝 フォールバック要約結果: $summarized');
+    DebugService().log('📝 フォールバック要約結果: $summarized');
     return summarized.isNotEmpty ? summarized : originalName;
   }
 }

--- a/lib/services/recipe_parser_service.dart
+++ b/lib/services/recipe_parser_service.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_functions/cloud_functions.dart';
-import 'package:flutter/foundation.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// レシピから抽出された材料のモデル
 class RecipeIngredient {
@@ -54,7 +54,7 @@ class RecipeParserService {
   /// レシピテキストから材料を抽出する（Cloud Functions経由）
   Future<RecipeParseResult?> parseRecipe(String recipeText) async {
     try {
-      debugPrint('🤖 レシピ解析開始（Cloud Functions経由）...');
+      DebugService().log('🤖 レシピ解析開始（Cloud Functions経由）...');
 
       final callable =
           FirebaseFunctions.instance.httpsCallable('parseRecipe');
@@ -71,17 +71,17 @@ class RecipeParserService {
                 RecipeIngredient.fromJson(Map<String, dynamic>.from(e as Map)))
             .toList();
 
-        debugPrint('✅ レシピ解析成功: 「$title」 ${ingredients.length}件の材料を抽出');
+        DebugService().log('✅ レシピ解析成功: 「$title」 ${ingredients.length}件の材料を抽出');
         return RecipeParseResult(title: title, ingredients: ingredients);
       } else {
-        debugPrint('❌ レシピ解析失敗: ${data['error']}');
+        DebugService().log('❌ レシピ解析失敗: ${data['error']}');
         return null;
       }
     } on FirebaseFunctionsException catch (e) {
-      debugPrint('❌ レシピ解析エラー: [${e.code}] ${e.message}');
+      DebugService().log('❌ レシピ解析エラー: [${e.code}] ${e.message}');
       return null;
     } catch (e) {
-      debugPrint('❌ レシピ解析例外: $e');
+      DebugService().log('❌ レシピ解析例外: $e');
       return null;
     }
   }
@@ -102,7 +102,7 @@ class RecipeParserService {
       final data = response.data;
       return data['isSame'] == true;
     } catch (e) {
-      debugPrint('⚠️ 同一性判定失敗: $e');
+      DebugService().log('⚠️ 同一性判定失敗: $e');
       return false;
     }
   }

--- a/lib/services/shared_group_service.dart
+++ b/lib/services/shared_group_service.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
 
 import 'data_service.dart';
 import '../models/shop.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// 共有グループ管理を担当するサービス
 ///
@@ -186,9 +186,9 @@ class SharedGroupService {
       for (final shop in shops) {
         await _dataService.updateShop(shop, isAnonymous: isAnonymous);
       }
-      debugPrint('✅ 共有グループ保存完了: ${shops.length}件');
+      DebugService().log('✅ 共有グループ保存完了: ${shops.length}件');
     } catch (e) {
-      debugPrint('❌ 共有グループ保存エラー: $e');
+      DebugService().log('❌ 共有グループ保存エラー: $e');
       rethrow;
     }
   }

--- a/lib/services/shop_service.dart
+++ b/lib/services/shop_service.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 
 import 'data_service.dart';
 import '../models/shop.dart';
 import '../models/list.dart';
 import '../drawer/settings/settings_persistence.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// ショップ（タブ）のCRUD操作を担当するサービス
 ///
@@ -34,9 +34,9 @@ class ShopService {
   Future<void> saveShop(Shop shop, {required bool isAnonymous}) async {
     try {
       await _dataService.saveShop(shop, isAnonymous: isAnonymous);
-      debugPrint('✅ ショップ保存完了: ${shop.name}');
+      DebugService().log('✅ ショップ保存完了: ${shop.name}');
     } catch (e) {
-      debugPrint('❌ Firebase保存エラー: $e');
+      DebugService().log('❌ Firebase保存エラー: $e');
       rethrow;
     }
   }
@@ -46,7 +46,7 @@ class ShopService {
     try {
       await _dataService.updateShop(shop, isAnonymous: isAnonymous);
     } catch (e) {
-      debugPrint('Firebase更新エラー: $e');
+      DebugService().log('Firebase更新エラー: $e');
       _throwUserFriendlyError(e, 'ショップの更新');
     }
   }
@@ -59,10 +59,10 @@ class ShopService {
       // デフォルトショップが削除された場合は状態を記録
       if (shopId == '0') {
         await SettingsPersistence.saveDefaultShopDeleted(true);
-        debugPrint('デフォルトショップの削除を記録しました');
+        DebugService().log('デフォルトショップの削除を記録しました');
       }
     } catch (e) {
-      debugPrint('Firebase削除エラー: $e');
+      DebugService().log('Firebase削除エラー: $e');
       _throwUserFriendlyError(e, 'ショップの削除');
     }
   }
@@ -87,7 +87,7 @@ class ShopService {
           clearSharedGroupIcon: updatedSharedTabs.isEmpty,
         ));
 
-        debugPrint('タブ ${shop.id} から削除対象 $deletedShopId への参照を削除');
+        DebugService().log('タブ ${shop.id} から削除対象 $deletedShopId への参照を削除');
       } else {
         result.add(shop);
       }
@@ -139,7 +139,7 @@ class ShopService {
       isAnonymous: isAnonymous,
     );
 
-    debugPrint('✅ ショップ ${shop.name} の全アイテムをクリア');
+    DebugService().log('✅ ショップ ${shop.name} の全アイテムをクリア');
   }
 
   /// ユーザーフレンドリーなエラーメッセージを投げる

--- a/lib/services/vision_ocr_service.dart
+++ b/lib/services/vision_ocr_service.dart
@@ -5,6 +5,7 @@ import 'package:cloud_functions/cloud_functions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:maikago/config.dart';
 import 'package:image/image.dart' as img;
+import 'package:maikago/services/debug_service.dart';
 
 class OcrItemResult {
   final String name;
@@ -41,7 +42,7 @@ class VisionOcrService {
       final resizedBytes = await _resizeImage(image);
       final b64 = base64Encode(resizedBytes);
 
-      debugPrint(
+      DebugService().log(
           '📸 Cloud Functionsへリクエスト送信中... (画像サイズ: ${resizedBytes.length} bytes)');
 
       onProgress?.call(
@@ -63,7 +64,7 @@ class VisionOcrService {
 
         if (name.isNotEmpty && price > 0) {
           onProgress?.call(OcrProgressStep.completed, '解析完了');
-          debugPrint('✅ Cloud Functions解析成功: name=$name, price=$price');
+          DebugService().log('✅ Cloud Functions解析成功: name=$name, price=$price');
           return OcrItemResult(name: name, price: price);
         }
       }
@@ -71,7 +72,7 @@ class VisionOcrService {
       // success: false の場合
       final error = data['error'] as String? ?? '商品情報の抽出に失敗しました';
       onProgress?.call(OcrProgressStep.failed, error);
-      debugPrint('⚠️ Cloud Functions解析失敗: $error');
+      DebugService().log('⚠️ Cloud Functions解析失敗: $error');
       return null;
     } on FirebaseFunctionsException catch (e) {
       String message;
@@ -89,16 +90,16 @@ class VisionOcrService {
           message = 'サーバーエラーが発生しました。';
       }
       onProgress?.call(OcrProgressStep.failed, message);
-      debugPrint('❌ Cloud Functionsエラー: [${e.code}] ${e.message}');
+      DebugService().log('❌ Cloud Functionsエラー: [${e.code}] ${e.message}');
       return null;
     } catch (e) {
       if (e.toString().contains('TimeoutException')) {
         onProgress?.call(
             OcrProgressStep.failed, 'タイムアウト: ネットワーク接続を確認してください');
-        debugPrint('⏰ Cloud Functionsタイムアウト');
+        DebugService().log('⏰ Cloud Functionsタイムアウト');
       } else {
         onProgress?.call(OcrProgressStep.failed, 'ネットワークエラーが発生しました');
-        debugPrint('❌ Cloud Functionsエラー: $e');
+        DebugService().log('❌ Cloud Functionsエラー: $e');
       }
       return null;
     }
@@ -111,7 +112,7 @@ class VisionOcrService {
       final originalImage = img.decodeImage(bytes);
 
       if (originalImage == null) {
-        debugPrint('⚠️ 画像のデコードに失敗しました');
+        DebugService().log('⚠️ 画像のデコードに失敗しました');
         return bytes;
       }
 
@@ -127,7 +128,7 @@ class VisionOcrService {
         // シャープ処理は環境差異が大きいためスキップ（必要なら別実装に差し替え）
       } catch (e) {
         // ランタイム差異でAPIが存在しない場合はそのまま進行
-        debugPrint('画像前処理エラー: $e');
+        DebugService().log('画像前処理エラー: $e');
       }
 
       // より積極的なリサイズで処理速度とOCR安定性を両立
@@ -157,7 +158,7 @@ class VisionOcrService {
         );
 
         final resizedBytes = img.encodeJpg(resizedImage, quality: quality);
-        debugPrint(
+        DebugService().log(
             '📏 画像を最適化（前処理＋リサイズ）: ${originalImage.width}x${originalImage.height} → ${resizedImage.width}x${resizedImage.height} (${bytes.length} → ${resizedBytes.length} bytes)');
         return resizedBytes;
       }
@@ -166,7 +167,7 @@ class VisionOcrService {
       if (bytes.length > 500000) {
         // 500KB以上の場合
         final optimizedBytes = img.encodeJpg(working, quality: quality);
-        debugPrint(
+        DebugService().log(
             '📏 画像品質を最適化: ${bytes.length} → ${optimizedBytes.length} bytes');
         return optimizedBytes;
       }
@@ -175,7 +176,7 @@ class VisionOcrService {
       final preprocessed = img.encodeJpg(working, quality: quality);
       return preprocessed;
     } catch (e) {
-      debugPrint('⚠️ 画像リサイズエラー: $e');
+      DebugService().log('⚠️ 画像リサイズエラー: $e');
       return await image.readAsBytes();
     }
   }

--- a/lib/utils/responsive_utils.dart
+++ b/lib/utils/responsive_utils.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:maikago/services/debug_service.dart';
 
 /// レスポンシブデザインのためのユーティリティクラス
 class ResponsiveUtils {
@@ -144,14 +145,14 @@ class ResponsiveUtils {
     final size = mediaQuery.size;
     final padding = mediaQuery.padding;
 
-    debugPrint('📱 デバイス情報:');
-    debugPrint('   画面サイズ: ${size.width.toInt()} x ${size.height.toInt()}');
-    debugPrint('   向き: ${getOrientation(context)}');
-    debugPrint(
+    DebugService().log('📱 デバイス情報:');
+    DebugService().log('   画面サイズ: ${size.width.toInt()} x ${size.height.toInt()}');
+    DebugService().log('   向き: ${getOrientation(context)}');
+    DebugService().log(
         '   パディング: top=${padding.top}, bottom=${padding.bottom}, left=${padding.left}, right=${padding.right}');
-    debugPrint(
+    DebugService().log(
         '   安全領域サイズ: ${getSafeAreaSize(context).width.toInt()} x ${getSafeAreaSize(context).height.toInt()}');
-    debugPrint(
+    DebugService().log(
         '   画面サイズ分類: ${isSmallScreen(context) ? '小' : isMediumScreen(context) ? '中' : '大'}');
   }
 }


### PR DESCRIPTION
## 概要
Issue #38 を解決。全538箇所のdebugPrintをDebugService経由に統一し、リリースビルドでのログ出力を完全抑制。

## 変更内容
- **DebugService改修**: 全ログメソッドのガードを`enableDebugMode`から`kDebugMode`に変更。リリースビルドでdebugPrint呼び出しを完全無効化
- **debugPrint統一**: 37ファイル538箇所の`debugPrint()`を`DebugService().log()`に置換
- **import整理**: 不要になった`foundation.dart`のimportを15ファイルから削除、2ファイルのshow句から`debugPrint`を削除

### DebugServiceのログメソッド体系
| メソッド | 用途 | 既存利用 |
|---------|------|---------|
| `log()` | 汎用ログ（全debugPrintの置換先） | 538箇所（新規） |
| `logDebug()` | デバッグ情報（🔍プレフィックス付き） | main.dart等 |
| `logWarning()` | 警告（⚠️プレフィックス付き） | main.dart等 |
| `logError()` | エラー（❌プレフィックス付き + スタックトレース対応） | main.dart等 |
| `logPerformance()` | パフォーマンス計測 | 既存 |

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（65テスト全パス）
- [ ] コードレビュー
- [ ] 実機動作確認

Closes #38
