### PR TITLE
fix(#73): リスト並べ替え時のカード背景二重表示を修正

### DIFF
--- a/lib/screens/main/widgets/item_list_section.dart
+++ b/lib/screens/main/widgets/item_list_section.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show lerpDouble;
+
 import 'package:flutter/material.dart';
 
 import 'package:maikago/models/list.dart';
@@ -142,6 +144,21 @@ class ItemListSection extends StatelessWidget {
                     cacheExtent: 250,
                     physics: const ClampingScrollPhysics(),
                     clipBehavior: Clip.hardEdge,
+                    proxyDecorator: (child, index, animation) {
+                      return AnimatedBuilder(
+                        animation: animation,
+                        builder: (context, child) {
+                          final animValue =
+                              Curves.easeInOut.transform(animation.value);
+                          final scale = lerpDouble(1, 1.03, animValue)!;
+                          return Transform.scale(
+                            scale: scale,
+                            child: child,
+                          );
+                        },
+                        child: child,
+                      );
+                    },
                     itemBuilder: (context, idx) {
                       final item = items[idx];
                       return ListEdit(


### PR DESCRIPTION
## 概要
Issue #73 を解決。リスト並べ替え時にカードの背景が二重表示される問題を修正。

## 変更内容
- `ReorderableListView.builder` に `proxyDecorator` を追加
- デフォルトの `Material` ラッパーによる二重背景を排除
- `Transform.scale` でドラッグ中のカードに軽い拡大効果（1.03倍）を付与し、自然な持ち上げ感を実現

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（180テスト全通過）
- [x] 実機動作確認

Closes #73
