### PR TITLE
fix(#75): 一括削除時のリアルタイム同期による中間状態上書きを防止

### DIFF
--- a/lib/providers/repositories/item_repository.dart
+++ b/lib/providers/repositories/item_repository.dart
@@ -386,6 +386,8 @@ class ItemRepository {
 
     // ローカルモードでない場合のみFirebaseから一括削除
     if (!_cacheManager.isLocalMode) {
+      // リアルタイム同期による中間状態の上書きを防止
+      _state.isBatchUpdating = true;
       try {
         // 並列で削除を実行（最大5つずつ）
         const batchSize = 5;
@@ -426,6 +428,9 @@ class ItemRepository {
         _state.notifyListeners();
 
         throw convertToAppException(e, contextMessage: 'アイテムの削除');
+      } finally {
+        _state.isBatchUpdating = false;
+        _state.notifyListeners();
       }
     }
   }


### PR DESCRIPTION
## 概要
Issue #75 を解決。一括削除時にアイテムが順々に消える問題を修正。

## 変更内容
- `deleteItems`のFirebase削除処理中に`isBatchUpdating`フラグを設定し、リアルタイム同期による中間状態の上書きを防止
- `finally`ブロックでフラグ解除と`notifyListeners()`を確実に実行

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（180テスト全パス）
- [x] 実機動作確認
- [ ] コードレビュー

Closes #75
