### PR TITLE
fix(#77): プレミアム購入済みユーザーのトライアルバッジ表示バグ修正

### DIFF
--- a/lib/screens/drawer/maikago_premium.dart
+++ b/lib/screens/drawer/maikago_premium.dart
@@ -164,7 +164,8 @@ class _SubscriptionScreenState extends State<SubscriptionScreen>
               ),
             ] else ...[
               // 体験期間未開始の場合
-              if (!purchaseService.isTrialEverStarted) ...[
+              if (!purchaseService.isPremiumUnlocked &&
+                  !purchaseService.isTrialEverStarted) ...[
                 Container(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 16, vertical: 8),


### PR DESCRIPTION
## 概要
Issue #77 を解決。プレミアム購入済みユーザーに「7日間無料でお試し！」バッジが表示されるバグを修正。

## 変更内容
- `_buildHeroSection` のトライアルバッジ表示条件に `!purchaseService.isPremiumUnlocked` チェックを追加
- `_buildPurchaseSection` で使用している `isPremiumUnlocked` と同じ判定基準に統一

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（全180テスト）
- [x] Chrome デバッグモードで動作確認済み

Closes #77
