### PR TITLE
fix(#99): Windowsクロスドライブ環境でのAndroidビルドエラーを修正

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,13 +48,6 @@ android {
         jvmTarget = '11'
     }
     
-    // Kotlinインクリメンタルキャッシュを無効化
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions {
-            freeCompilerArgs += ["-Xno-incremental"]
-        }
-    }
-
     // ネイティブライブラリのアライメント設定
     packagingOptions {
         jniLibs {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,11 @@ allprojects {
 
 rootProject.buildDir = '../build'
 subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    // Windows環境でプロジェクトとビルドディレクトリのドライブが異なる場合はスキップ
+    def targetBuildDir = file("${rootProject.buildDir}/${project.name}")
+    if (targetBuildDir.toPath().root == project.projectDir.toPath().root) {
+        project.buildDir = targetBuildDir
+    }
 }
 subprojects {
     project.evaluationDependsOn(':app')

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,6 +3,9 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.enableR8.fullMode=false
 
+# Windows環境でのクロスドライブ問題を回避（Pubキャッシュとプロジェクトが異なるドライブの場合）
+kotlin.incremental=false
+
 # ビルド時間短縮のための設定
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## 概要
Issue #99 を解決。Windows環境でプロジェクト（D:ドライブ）とPubキャッシュ（C:ドライブ）が異なるドライブにある場合、Androidビルドが失敗する問題を修正。

## 変更内容
- `android/build.gradle` - subprojectsのbuildDir設定にドライブルート一致チェックを追加
- `android/gradle.properties` - `kotlin.incremental=false` を追加し全プロジェクトでインクリメンタルキャッシュを無効化
- `android/app/build.gradle` - 重複していた `-Xno-incremental` 設定を削除

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（233テスト）
- [x] flutter build apk --debug 成功

Closes #99
