### PR TITLE
chore: ビルド番号を+57に更新

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maikago
 description: "まいカゴ – 買いすぎ防止のための買い物リスト管理アプリ"
 publish_to: 'none'
-version: 1.4.0+56
+version: 1.4.0+57
 environment:
   sdk: '>=3.0.0 <4.0.0'
 


### PR DESCRIPTION
## Summary
- `pubspec.yaml` のビルド番号を +56 → +57 に更新

## Test plan
- [x] `flutter pub get` が正常に完了すること
- [x] ビルドが正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)