### PR TITLE
style(#117): 合計金額テキストの配色を改善

### DIFF
--- a/lib/screens/main/dialogs/item_edit_dialog.dart
+++ b/lib/screens/main/dialogs/item_edit_dialog.dart
@@ -7,6 +7,7 @@ import 'package:maikago/utils/dialog_utils.dart';
 import 'package:maikago/models/list.dart';
 import 'package:maikago/models/shop.dart';
 import 'package:maikago/services/settings_persistence.dart';
+import 'package:maikago/services/settings_theme.dart';
 import 'package:maikago/utils/snackbar_utils.dart';
 import 'package:go_router/go_router.dart';
 
@@ -259,7 +260,7 @@ class _ItemEditDialogState extends State<ItemEditDialog> {
                         fontWeight: FontWeight.bold,
                         color: Theme.of(context).brightness == Brightness.dark
                             ? Colors.white
-                            : Theme.of(context).colorScheme.primary,
+                            : AppColors.textPrimary,
                         fontSize: Theme.of(context).textTheme.bodyLarge?.fontSize,
                       ),
                     ),


### PR DESCRIPTION
## 概要
Issue #117 を解決。リスト追加ダイアログの合計金額テキストの配色を改善。

## 変更内容
- ライトモード時の合計金額テキスト色を `colorScheme.primary` → `AppColors.textPrimary` に変更
- 淡いテーマ（ピンク、ベージュ等）での視認性を向上

## テスト
- [x] flutter analyze 通過
- [x] flutter test 通過（256テスト全通過）

Closes #117
