### PR TITLE
fix: アプリ表示名を「まいカゴ」に短縮

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <application
-        android:label="まいカゴ – 買い物リスト×電卓で買いすぎ防止"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon"
         android:extractNativeLibs="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>まいカゴ – 買い物リスト×電卓で買いすぎ防止</string>
+	<string>まいカゴ</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## 変更内容

- `android/app/src/main/AndroidManifest.xml`: `android:label` を `@string/app_name` 参照に変更（strings.xml の「まいカゴ」を使用）
- `ios/Runner/Info.plist`: `CFBundleDisplayName` を「まいカゴ」に短縮

## 背景

端末のホーム画面に表示されるアプリ名が「まいカゴ – 買い物リスト×電卓で買いすぎ防止」と長すぎたため、「まいカゴ」のみに統一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)