### PR TITLE
ci: Dependabot PRではプレビューデプロイをスキップ

### DIFF
--- a/.github/workflows/firebase-hosting-pr.yml
+++ b/.github/workflows/firebase-hosting-pr.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   preview-deploy:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要

- DependabotはGitHubのセキュリティ制約でリポジトリsecretにアクセスできない
- そのため `flutter build web` が失敗し、全Dependabot PRでpreview-deployが赤になっていた
- `if: github.actor != 'dependabot[bot]'` を追加してスキップするよう修正

## 影響

- Dependabot PR: preview-deployがスキップ（赤→グレー）
- 自分のPR: 変わらずプレビューURLが発行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)