### PR TITLE
chore: Kotlin Gradle Plugin を 2.1.0 → 2.3.0 に更新

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.3.0'
     repositories {
         google()
         mavenCentral()

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.9.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## 概要

`google_mobile_ads 9.0.0` が依存する `play-services-ads 25.3.0` が Kotlin 2.3.0 のバイナリで作られているため、Kotlin Gradle Plugin が 2.1.0 のままだと APK ビルドが次のエラーで失敗する。

```
Module was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 2.3.0, expected version is 2.1.0.
```

## 変更内容

- `android/settings.gradle`: `org.jetbrains.kotlin.android` を `2.1.0` → `2.3.0`
- `android/build.gradle`: `ext.kotlin_version` を `2.1.0` → `2.3.0`

## 関連

このPRがマージされた後、Dependabot PR #180（google_mobile_ads 7→9）に `@dependabot rebase` を送ってCIを再実行する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)