### PR TITLE
ci: Dependabot PRのCIが通ったら自動マージを設定

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot PR が作成・更新されるたびに自動で `--auto merge` を設定するワークフローを追加。

これにより今後は Dependabot PR のCIが通り次第、手動操作なしで自動マージされる。

## 動作

1. Dependabot が PR を作成・更新
2. このワークフローが発火して `gh pr merge --auto --merge` を実行
3. 必須チェック（Analyze / Build / Format / Secrets Scan / Test）が全て通ったら GitHub が自動マージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)