### PR TITLE
chore(ci): セッション開始・マージ後にmain自動pullするフックを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git checkout main && git pull 2>/dev/null || true",
+            "statusMessage": "mainに切り替えてpull中..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
@@ -7,6 +18,17 @@
           {
             "type": "command",
             "command": "FILE=$(jq -r '.tool_input.file_path // empty'); if [[ \"$FILE\" == *.dart ]]; then dart format \"$FILE\" 2>/dev/null || true; fi"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(gh pr merge *)",
+            "command": "git checkout main && git pull 2>/dev/null || true",
+            "statusMessage": "mainに切り替えてpull中..."
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `SessionStart` フック: `/clear` やセッション開始時に `git checkout main && git pull` を自動実行
- `PostToolUse(Bash)` フック: `gh pr merge` 実行直後に同様の処理を自動実行

毎回手動でやっていた「マージ後に main に切り替えて pull する」作業を自動化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)