### PR TITLE
fix(#157): discount等の入力値バリデーション追加（合計金額の負数化を防止）

### DIFF
--- a/lib/models/list.dart
+++ b/lib/models/list.dart
@@ -1,11 +1,14 @@
 // リスト項目（数量・単価・割引・チェック状態）
 class ListItem {
+  // Issue #157: discount/price/quantity を範囲補正する唯一の入口。
+  // fromJson・copyWith・直接生成のすべてがこのコンストラクタを通るため、
+  // ここで正規化すれば全経路で不正値（負数・100%超割引）を防げる。
   ListItem({
     required this.id,
     required this.name,
-    required this.quantity,
-    required this.price,
-    this.discount = 0.0,
+    required int quantity,
+    required int price,
+    double discount = 0.0,
     this.isChecked = false,
     required this.shopId,
     this.createdAt,
@@ -18,7 +21,9 @@ class ListItem {
     this.sortOrder = 0,
     this.isRecipeOrigin = false,
     this.recipeName,
-  });
+  })  : quantity = quantity < 0 ? 0 : quantity,
+        price = price < 0 ? 0 : price,
+        discount = discount.clamp(0.0, 1.0);
 
   factory ListItem.fromJson(Map<String, dynamic> json) => ListItem(
         id: json['id']?.toString() ?? '',

--- a/lib/screens/main/dialogs/item_edit_dialog.dart
+++ b/lib/screens/main/dialogs/item_edit_dialog.dart
@@ -226,6 +226,8 @@ class _ItemEditDialogState extends State<ItemEditDialog> {
                 inputFormatters: [
                   FilteringTextInputFormatter.digitsOnly,
                   noLeadingZeroFormatter(),
+                  // Issue #157: 割引率は100%まで（150%引き等を入力させない）
+                  maxValueFormatter(100),
                 ],
                 onChanged: (value) => setState(() {}),
               ),

--- a/lib/utils/input_formatters.dart
+++ b/lib/utils/input_formatters.dart
@@ -19,3 +19,18 @@ TextInputFormatter noLeadingZeroFormatter({bool allowSingleZero = false}) {
     return newValue;
   });
 }
+
+/// 数値入力の上限を超えさせないフォーマッター
+///
+/// Issue #157: 割引率(%)など範囲のある入力欄で使う。
+/// [max] を超える値が入力された場合は変更を拒否し、変更前の値を維持する。
+/// 数値として解釈できない入力（空文字を除く）も変更前を維持する。
+TextInputFormatter maxValueFormatter(int max) {
+  return TextInputFormatter.withFunction((oldValue, newValue) {
+    if (newValue.text.isEmpty) return newValue;
+    final value = int.tryParse(newValue.text);
+    if (value == null) return oldValue;
+    if (value > max) return oldValue;
+    return newValue;
+  });
+}

--- a/lib/widgets/list_item_edit_dialog.dart
+++ b/lib/widgets/list_item_edit_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:maikago/models/list.dart';
+import 'package:maikago/utils/input_formatters.dart';
 import 'package:maikago/widgets/common_dialog.dart';
 
 /// リスト編集ダイアログ
@@ -251,6 +252,8 @@ class _ListItemEditDialogState extends State<ListItemEditDialog> {
                     }
                     return newValue;
                   }),
+                  // Issue #157: 割引率は100%まで（150%引き等を入力させない）
+                  maxValueFormatter(100),
                 ],
                 onChanged: _updateDiscount,
               ),

--- a/test/models/list_item_test.dart
+++ b/test/models/list_item_test.dart
@@ -257,5 +257,87 @@ void main() {
         expect(item.priceWithTax, 295);
       });
     });
+
+    // Issue #157: discount/price/quantity の入力値バリデーション
+    group('入力値バリデーション（Issue #157）', () {
+      group('コンストラクタで範囲補正される', () {
+        test('discountが1.0を超える場合は1.0に補正される', () {
+          final item = createSampleItem(discount: 1.5);
+          expect(item.discount, 1.0);
+        });
+
+        test('discountが0.0未満の場合は0.0に補正される', () {
+          final item = createSampleItem(discount: -0.2);
+          expect(item.discount, 0.0);
+        });
+
+        test('priceが負数の場合は0に補正される', () {
+          final item = createSampleItem(price: -100);
+          expect(item.price, 0);
+        });
+
+        test('quantityが負数の場合は0に補正される', () {
+          final item = createSampleItem(quantity: -5);
+          expect(item.quantity, 0);
+        });
+
+        test('正常範囲の値はそのまま保持される', () {
+          final item = createSampleItem(discount: 0.3, price: 200, quantity: 2);
+          expect(item.discount, 0.3);
+          expect(item.price, 200);
+          expect(item.quantity, 2);
+        });
+      });
+
+      group('fromJsonで範囲補正される', () {
+        ListItem restore(Map<String, dynamic> overrides) => ListItem.fromJson({
+              'id': '1',
+              'name': 'テスト',
+              'quantity': 1,
+              'price': 100,
+              'shopId': '0',
+              ...overrides,
+            });
+
+        test('discount=1.5（150%引き）は1.0に補正される', () {
+          expect(restore({'discount': 1.5}).discount, 1.0);
+        });
+
+        test('discount=-0.2は0.0に補正される', () {
+          expect(restore({'discount': -0.2}).discount, 0.0);
+        });
+
+        test('price=-100は0に補正される', () {
+          expect(restore({'price': -100}).price, 0);
+        });
+
+        test('quantity=-5は0に補正される', () {
+          expect(restore({'quantity': -5}).quantity, 0);
+        });
+      });
+
+      group('copyWithで範囲補正される', () {
+        test('範囲外のdiscountを渡すと補正される', () {
+          final item = createSampleItem(discount: 0.1);
+          expect(item.copyWith(discount: 2.0).discount, 1.0);
+          expect(item.copyWith(discount: -1.0).discount, 0.0);
+        });
+
+        test('範囲外のprice/quantityを渡すと補正される', () {
+          final item = createSampleItem();
+          expect(item.copyWith(price: -50).price, 0);
+          expect(item.copyWith(quantity: -3).quantity, 0);
+        });
+      });
+
+      test('補正後の値は合計金額が負数にならない', () {
+        // 壊れた割引率1.5でも (1 - clamp(1.5)) = 0 となり負数にならない
+        final item = createSampleItem(price: 500, quantity: 2, discount: 1.5);
+        final total =
+            (item.price * item.quantity * (1 - item.discount)).round();
+        expect(total, greaterThanOrEqualTo(0));
+        expect(total, 0);
+      });
+    });
   });
 }

--- a/test/utils/input_formatters_test.dart
+++ b/test/utils/input_formatters_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maikago/utils/input_formatters.dart';
+
+void main() {
+  // 入力UIに渡す TextEditingValue を組み立てるヘルパー
+  TextEditingValue v(String text) => TextEditingValue(
+        text: text,
+        selection: TextSelection.collapsed(offset: text.length),
+      );
+
+  group('maxValueFormatter（Issue #157）', () {
+    test('上限以下の値はそのまま通す', () {
+      final f = maxValueFormatter(100);
+      expect(f.formatEditUpdate(v('5'), v('50')).text, '50');
+      expect(f.formatEditUpdate(v('10'), v('100')).text, '100');
+    });
+
+    test('上限を超える値は拒否され、変更前の値を維持する', () {
+      final f = maxValueFormatter(100);
+      // 100 → 150 への変更は拒否され、直前の "100" が維持される
+      expect(f.formatEditUpdate(v('100'), v('150')).text, '100');
+    });
+
+    test('空文字は許可する（入力途中のクリアを妨げない）', () {
+      final f = maxValueFormatter(100);
+      expect(f.formatEditUpdate(v('5'), v('')).text, '');
+    });
+
+    test('数値として解釈できない入力は変更前を維持する', () {
+      final f = maxValueFormatter(100);
+      expect(f.formatEditUpdate(v('50'), v('abc')).text, '50');
+    });
+  });
+}


### PR DESCRIPTION
## 対応Issue
Closes #157

## 背景・問題
- Firestoreや移行データに不正な割引率（例: `1.5` = 150%引き）が混入すると、`(1 - discount)` が負になり**合計金額が負数**で表示される。
- `price` / `quantity` の負数もデータ境界では防御されていなかった。

## 変更内容
### 1. データ境界の一元防御（`lib/models/list.dart`）
- `ListItem` コンストラクタで `discount.clamp(0.0, 1.0)`、`price`/`quantity` を `0以上` に補正。
- `fromJson` / `copyWith` / 直接生成のすべてがこのコンストラクタを通るため、**1箇所で全経路を防御**（同一ロジックの分散を回避）。

### 2. 入力UIの防御
- `input_formatters.dart` に `maxValueFormatter(max)` を追加。
- `item_edit_dialog.dart` / `list_item_edit_dialog.dart` の割引率入力欄を **0〜100%** に制限（従来は最大999%まで入力可能だった）。

### 3. テスト
- `list_item_test.dart`: コンストラクタ / fromJson / copyWith での範囲補正、補正後に合計が非負になることを検証。
- `input_formatters_test.dart`（新規）: 上限超過の拒否・空文字許可・非数値の扱い。

## 完了条件の確認
- [x] 範囲外値（discount=1.5, -0.2 / price=-100 等）を含むJSONからの復元で正常値に補正されるユニットテスト
- [x] 合計が負数にならないことのテスト
- [x] `flutter analyze` エラー0 / `flutter test` 全413件パス

## テスト
- `flutter analyze` → No issues found
- `flutter test` → All tests passed (413件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)