### PR TITLE
fix(#155): OCR使用回数を保存成功時のみ消費するよう修正

### DIFF
--- a/lib/screens/main/widgets/bottom_summary_actions.dart
+++ b/lib/screens/main/widgets/bottom_summary_actions.dart
@@ -19,6 +19,13 @@ import 'package:maikago/widgets/image_analysis_progress_dialog.dart';
 import 'package:maikago/widgets/premium_upgrade_dialog.dart';
 import 'package:maikago/widgets/recipe_import_bottom_sheet.dart';
 
+/// OCR保存結果から「使用回数を消費すべきか」を判定する。
+///
+/// Issue #155: 確認画面のキャンセル（`null`）・保存失敗では消費しない。
+/// 保存が成功した（＝ユーザーが値を得た）ときのみ `true` を返す。
+bool shouldConsumeOcrUsage(SaveResult? saveResult) =>
+    saveResult != null && saveResult.isSuccess;
+
 /// ボトムサマリーのアクションボタン群
 /// 予算変更・カメラ撮影・レシピ解析・リスト追加ボタンを含む
 class BottomSummaryActions extends StatefulWidget {
@@ -199,14 +206,13 @@ class _BottomSummaryActionsState extends State<BottomSummaryActions> {
 
       if (!mounted) return;
 
-      // 保存結果に応じてメッセージを表示
-      if (saveResult != null && saveResult.isSuccess) {
-        showSuccessSnackBar(context, saveResult.message,
+      // 保存成功時のみメッセージ表示とOCR使用回数の消費を行う。
+      // Issue #155: キャンセル・保存失敗ではカウントを増やさない。
+      if (shouldConsumeOcrUsage(saveResult)) {
+        showSuccessSnackBar(context, saveResult!.message,
             duration: const Duration(seconds: 2));
+        context.read<FeatureAccessControl>().incrementOcrUsage();
       }
-
-      // OCR成功時にカウンターを増加
-      context.read<FeatureAccessControl>().incrementOcrUsage();
     } catch (e) {
       DebugService().logError('値札画像処理エラー: $e');
       if (mounted) {

--- a/test/screens/ocr_usage_policy_test.dart
+++ b/test/screens/ocr_usage_policy_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:maikago/models/ocr_session_result.dart';
+import 'package:maikago/screens/main/widgets/bottom_summary_actions.dart';
+
+/// Issue #155: OCR使用回数の消費可否判定
+///
+/// 確認画面のキャンセル・保存失敗ではカウントを消費せず、
+/// 保存が成功したときのみ消費する仕様を検証する。
+void main() {
+  group('shouldConsumeOcrUsage', () {
+    test('キャンセル（null）では消費しない', () {
+      expect(shouldConsumeOcrUsage(null), isFalse);
+    });
+
+    test('保存失敗では消費しない', () {
+      final result = SaveResult.failure('保存に失敗しました');
+      expect(shouldConsumeOcrUsage(result), isFalse);
+    });
+
+    test('保存成功でのみ消費する', () {
+      final result = SaveResult.success(message: '1件追加しました');
+      expect(shouldConsumeOcrUsage(result), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
Issue #155 を解決。OCR結果確認画面でキャンセルしても無料枠が1回分消費されるバグを修正。

## 原因
`bottom_summary_actions.dart` の `_handleImageCaptured()` で、`incrementOcrUsage()` が保存成功判定の `if` ブロックの**外**にあり、キャンセル（戻り値 `null`）・保存失敗でも常に実行されていた。

## 変更内容
- 消費可否判定を純粋関数 `shouldConsumeOcrUsage(SaveResult?)` に切り出し（キャンセル `null`・保存失敗 → false、保存成功 → true）
- `incrementOcrUsage()` を成功ブロック内へ移動。成功SnackBar表示と消費の発火条件を統合
- 仕様: 「保存成功でユーザーが価値を得た時点でのみ消費」（CLAUDE.md ドメインルール準拠）
- カウント挙動のユニットテストを追加（`test/screens/ocr_usage_policy_test.dart`）

## 横断確認
OCRカウントの呼び出しはこの1箇所のみ。レシピ取り込みはプレミアム限定機能で月間カウントを持たないため同種のズレなし。

## テスト
- [x] flutter analyze 通過（No issues found）
- [x] flutter test 通過（416件 All tests passed）
- [ ] コードレビュー（code-reviewプラグイン）
- [ ] 実機動作確認（テストで代替）

Closes #155
