### PR TITLE
fix(#156): 金額計算ロジックを共通関数に統一し丸め順序の不一致を解消

### DIFF
--- a/lib/providers/managers/shared_tab_manager.dart
+++ b/lib/providers/managers/shared_tab_manager.dart
@@ -5,6 +5,7 @@ import 'package:maikago/providers/data_provider_state.dart';
 import 'package:maikago/providers/managers/data_cache_manager.dart';
 import 'package:maikago/providers/repositories/shop_repository.dart';
 import 'package:maikago/services/debug_service.dart';
+import 'package:maikago/utils/calculation_utils.dart';
 
 /// 共有タブの管理を担うクラス。
 /// - 共有タブの作成・更新・削除
@@ -29,14 +30,7 @@ class SharedTabManager {
 
   // --- 合計・予算計算 ---
 
-  int getDisplayTotal(Shop shop) {
-    final checkedItems = shop.items.where((item) => item.isChecked).toList();
-    return checkedItems.fold<int>(0, (sum, item) {
-      final itemTotal =
-          (item.price * item.quantity * (1 - item.discount)).round();
-      return sum + itemTotal;
-    });
-  }
+  int getDisplayTotal(Shop shop) => calcShopTotal(shop);
 
   int getSharedTabTotal(String sharedTabGroupId) {
     final sharedShops = _cacheManager.shops

--- a/lib/screens/main/dialogs/item_edit_dialog.dart
+++ b/lib/screens/main/dialogs/item_edit_dialog.dart
@@ -6,6 +6,7 @@ import 'package:maikago/providers/data_provider.dart';
 import 'package:maikago/models/list.dart';
 import 'package:maikago/models/shop.dart';
 import 'package:maikago/services/settings_persistence.dart';
+import 'package:maikago/utils/calculation_utils.dart';
 import 'package:maikago/utils/input_formatters.dart';
 import 'package:maikago/widgets/common_dialog.dart';
 import 'package:go_router/go_router.dart';
@@ -78,7 +79,11 @@ class _ItemEditDialogState extends State<ItemEditDialog> {
     final price = int.tryParse(priceController.text) ?? 0;
     final qty = int.tryParse(qtyController.text) ?? 1;
     final discountPercent = int.tryParse(discountController.text) ?? 0;
-    return (price * qty * (1 - discountPercent / 100.0)).round();
+    return calcItemTotalRaw(
+      price: price,
+      quantity: qty,
+      discount: discountPercent / 100.0,
+    );
   }
 
   Future<void> _handleSave() async {

--- a/lib/screens/main/utils/ui_calculations.dart
+++ b/lib/screens/main/utils/ui_calculations.dart
@@ -1,5 +1,4 @@
 import 'package:maikago/models/list.dart';
-import 'package:maikago/models/shop.dart';
 import 'package:maikago/models/sort_mode.dart';
 
 /// MainScreen用の静的ユーティリティクラス
@@ -59,15 +58,5 @@ class MainScreenCalculations {
               b.createdAt ?? DateTime.now(),
             );
     }
-  }
-
-  /// 購入済みアイテムの合計金額を計算
-  static int calcTotal(Shop currentShop, {bool includeTax = false}) {
-    int total = 0;
-    for (final item in currentShop.items.where((e) => e.isChecked)) {
-      final price = (item.price * (1 - item.discount)).round();
-      total += price * item.quantity;
-    }
-    return includeTax ? (total * 1.1).round() : total;
   }
 }

--- a/lib/screens/main/widgets/bottom_summary_widget.dart
+++ b/lib/screens/main/widgets/bottom_summary_widget.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'package:maikago/providers/data_provider.dart';
 import 'package:maikago/models/shop.dart';
+import 'package:maikago/utils/calculation_utils.dart';
 import 'package:maikago/services/settings_persistence.dart';
 import 'package:maikago/services/debug_service.dart';
 import 'package:maikago/screens/main/widgets/bottom_summary_actions.dart';
@@ -141,14 +142,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
   }
 
   // 現在のショップの即座の合計を計算
-  int _calculateCurrentShopTotal() {
-    int total = 0;
-    for (final item in widget.shop.items.where((e) => e.isChecked)) {
-      final price = (item.price * (1 - item.discount)).round();
-      total += price * item.quantity;
-    }
-    return total;
-  }
+  int _calculateCurrentShopTotal() => calcShopTotal(widget.shop);
 
   // 全てのサマリーデータを一度に取得
   Future<Map<String, dynamic>> _getAllSummaryData() async {

--- a/lib/utils/calculation_utils.dart
+++ b/lib/utils/calculation_utils.dart
@@ -1,0 +1,45 @@
+// 金額計算の唯一の正となるユーティリティ（Issue #156）。
+//
+// 丸めは「アイテム単位（数量を掛けてから）で1回」に統一する。
+// 合計・割引の計算式を screens / widgets に直書きせず、必ずこの関数群を使うこと。
+// 依存方向は utils → models の一方向のみ（models からは import しない）。
+import 'package:maikago/models/list.dart';
+import 'package:maikago/models/shop.dart';
+
+/// 素の値から1アイテムの小計を計算する（数量込み・割引後）。
+///
+/// 丸めは数量を掛けた後に1回だけ行う（`(price × quantity × (1 - discount)).round()`）。
+/// 単価で丸めてから数量を掛けると、割引で端数が出たとき合計が個数分ズレるため禁止。
+/// discount は 0.0〜1.0 にクランプして不正値（負数・100%超割引）を防ぐ。
+int calcItemTotalRaw({
+  required int price,
+  required int quantity,
+  required double discount,
+}) {
+  final d = discount.clamp(0.0, 1.0);
+  return (price * quantity * (1 - d)).round();
+}
+
+/// 1アイテムの小計（数量込み・割引後）。
+int calcItemTotal(ListItem item) => calcItemTotalRaw(
+      price: item.price,
+      quantity: item.quantity,
+      discount: item.discount,
+    );
+
+/// ショップ内アイテムの合計。既定はチェック済みのみ集計する。
+///
+/// 全件を集計する場合は [checkedOnly] を false にする。
+int calcShopTotal(Shop shop, {bool checkedOnly = true}) {
+  final items =
+      checkedOnly ? shop.items.where((item) => item.isChecked) : shop.items;
+  return items.fold<int>(0, (sum, item) => sum + calcItemTotal(item));
+}
+
+/// 1個あたりの割引後単価（数量を掛けない表示用）。
+///
+/// 単価そのものの表示に使う。合計には使わないこと（合計は [calcItemTotal] / [calcShopTotal]）。
+int calcDiscountedUnitPrice(int price, double discount) {
+  final d = discount.clamp(0.0, 1.0);
+  return (price * (1 - d)).round();
+}

--- a/lib/widgets/existing_list_selector_dialog.dart
+++ b/lib/widgets/existing_list_selector_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:maikago/models/shop.dart';
+import 'package:maikago/utils/calculation_utils.dart';
 import 'package:maikago/widgets/common_dialog.dart';
 
 /// 既存リスト選択ダイアログ
@@ -196,12 +197,6 @@ class ExistingListSelectorDialog extends StatelessWidget {
     );
   }
 
-  int _calculateTotalPrice(Shop shop) {
-    int total = 0;
-    for (final item in shop.items) {
-      final price = (item.price * (1 - item.discount)).round();
-      total += price * item.quantity;
-    }
-    return total;
-  }
+  int _calculateTotalPrice(Shop shop) =>
+      calcShopTotal(shop, checkedOnly: false);
 }

--- a/lib/widgets/list_edit.dart
+++ b/lib/widgets/list_edit.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:maikago/models/list.dart';
+import 'package:maikago/utils/calculation_utils.dart';
 import 'package:maikago/widgets/common_dialog.dart';
 import 'package:maikago/widgets/list_item_edit_dialog.dart';
 
@@ -218,7 +219,7 @@ class _ListEditState extends State<ListEdit> {
                                                 ),
                                               ),
                                               Text(
-                                                '¥${(widget.item.price * (1 - widget.item.discount)).round()}',
+                                                '¥${calcDiscountedUnitPrice(widget.item.price, widget.item.discount)}',
                                                 style: TextStyle(
                                                   color: colorScheme.error,
                                                   fontWeight: FontWeight.bold,

--- a/lib/widgets/list_item_edit_dialog.dart
+++ b/lib/widgets/list_item_edit_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:maikago/models/list.dart';
+import 'package:maikago/utils/calculation_utils.dart';
 import 'package:maikago/utils/input_formatters.dart';
 import 'package:maikago/widgets/common_dialog.dart';
 
@@ -279,7 +280,7 @@ class _ListItemEditDialogState extends State<ListItemEditDialog> {
                       ),
                     ),
                     Text(
-                      '¥${(_price * _quantity * (1 - _discount)).round()}',
+                      '¥${calcItemTotalRaw(price: _price, quantity: _quantity, discount: _discount)}',
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
                         color: Theme.of(context).colorScheme.primary,

--- a/test/providers/managers/shared_tab_manager_test.dart
+++ b/test/providers/managers/shared_tab_manager_test.dart
@@ -135,6 +135,17 @@ void main() {
       // 333 * 1 * 0.9 = 299.7 → 300
       expect(total, 300);
     });
+
+    test('複数個×割引の丸めはアイテム単位で1回（Issue #156）', () {
+      final shop = createSampleShop(items: [
+        createSampleItem(
+            price: 101, quantity: 3, discount: 0.5, isChecked: true),
+      ]);
+
+      // (101 * 3 * 0.5) = 151.5 → round() = 152
+      // 単価で丸める旧実装なら (101*0.5).round()=51 → ×3 = 153 とズレていた
+      expect(manager.getDisplayTotal(shop), 152);
+    });
   });
 
   group('getSharedTabTotal', () {

--- a/test/utils/calculation_utils_test.dart
+++ b/test/utils/calculation_utils_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maikago/utils/calculation_utils.dart';
+import '../helpers/test_helpers.dart';
+
+void main() {
+  group('calcItemTotalRaw', () {
+    test('割引なし: price × quantity', () {
+      expect(calcItemTotalRaw(price: 100, quantity: 2, discount: 0.0), 200);
+    });
+
+    test('割引あり: 端数なし', () {
+      // 1000 × 1 × (1 - 0.1) = 900
+      expect(calcItemTotalRaw(price: 1000, quantity: 1, discount: 0.1), 900);
+    });
+
+    test('丸めは「×個数してから1回」: 101円×50%引×3個 = 152円（単価丸めの153ではない）', () {
+      // (101 × 3 × 0.5) = 151.5 → round() = 152
+      // 単価丸め(バグ派)なら (101×0.5).round()=51 → ×3 = 153 になる
+      expect(calcItemTotalRaw(price: 101, quantity: 3, discount: 0.5), 152);
+    });
+
+    test('discountが1.0超はクランプされ合計0', () {
+      expect(calcItemTotalRaw(price: 500, quantity: 2, discount: 1.5), 0);
+    });
+
+    test('discountが負はクランプされ割引なし扱い', () {
+      expect(calcItemTotalRaw(price: 100, quantity: 1, discount: -0.5), 100);
+    });
+
+    test('価格0・数量0は0', () {
+      expect(calcItemTotalRaw(price: 0, quantity: 5, discount: 0.0), 0);
+      expect(calcItemTotalRaw(price: 100, quantity: 0, discount: 0.0), 0);
+    });
+  });
+
+  group('calcItemTotal(ListItem)', () {
+    test('ListItemの値で小計を返す（×個数してから丸め）', () {
+      final item = createSampleItem(price: 101, quantity: 3, discount: 0.5);
+      expect(calcItemTotal(item), 152);
+    });
+  });
+
+  group('calcShopTotal', () {
+    test('既定はチェック済みのみ合計', () {
+      final shop = createSampleShop(items: [
+        createSampleItem(id: '1', price: 100, quantity: 1, isChecked: true),
+        createSampleItem(id: '2', price: 500, quantity: 1, isChecked: false),
+      ]);
+      expect(calcShopTotal(shop), 100);
+    });
+
+    test('checkedOnly:false は全件合計', () {
+      final shop = createSampleShop(items: [
+        createSampleItem(id: '1', price: 100, quantity: 1, isChecked: true),
+        createSampleItem(id: '2', price: 500, quantity: 1, isChecked: false),
+      ]);
+      expect(calcShopTotal(shop, checkedOnly: false), 600);
+    });
+
+    test('合計はアイテム単位で丸めてから加算する', () {
+      // 各アイテム 101×50%引×3個 = 152 → 合計 304
+      final shop = createSampleShop(items: [
+        createSampleItem(
+            id: '1', price: 101, quantity: 3, discount: 0.5, isChecked: true),
+        createSampleItem(
+            id: '2', price: 101, quantity: 3, discount: 0.5, isChecked: true),
+      ]);
+      expect(calcShopTotal(shop), 304);
+    });
+
+    test('アイテムがない場合は0', () {
+      expect(calcShopTotal(createSampleShop()), 0);
+    });
+  });
+
+  group('calcDiscountedUnitPrice', () {
+    test('1個あたりの割引後単価（数量を掛けない）', () {
+      // 101 × 0.5 = 50.5 → round() = 51
+      expect(calcDiscountedUnitPrice(101, 0.5), 51);
+    });
+
+    test('割引なしはそのまま', () {
+      expect(calcDiscountedUnitPrice(298, 0.0), 298);
+    });
+
+    test('discountクランプ', () {
+      expect(calcDiscountedUnitPrice(100, 1.5), 0);
+      expect(calcDiscountedUnitPrice(100, -0.5), 100);
+    });
+  });
+}


### PR DESCRIPTION
## 対応Issue
Closes #156

## 問題
合計金額の計算式が6箇所以上に重複し、丸めのタイミングが統一されていなかったため、**同じ店の合計が表示場所によって1円単位でズレていた**。

- **下部合計バー**（`bottom_summary_widget`）＝ 単価で丸めてから×個数（バグ派）
- **共有タブ合計**（`getDisplayTotal`）＝ ×個数してから丸め（正派）

例: 単価101円・50%引・3個 → バグ派 **153円** / 正派 **152円**

## 修正方針
丸めを「**アイテム単位（×個数してから）で1回**」に統一（CLAUDE.md の唯一の正の式に準拠）。計算式を `lib/utils/calculation_utils.dart` に集約し、直書きを排除。

### 新設: `lib/utils/calculation_utils.dart`
| 関数 | 用途 |
|------|------|
| `calcItemTotalRaw({price, quantity, discount})` | 素の値から小計（×個数してから丸め） |
| `calcItemTotal(ListItem)` | ListItem の小計 |
| `calcShopTotal(Shop, {checkedOnly=true})` | ショップ合計 |
| `calcDiscountedUnitPrice(price, discount)` | 1個あたり割引後単価（数量を掛けない表示用） |

### 置換した7箇所
| 箇所 | 変更 | 表示値の変化 |
|------|------|------|
| `shared_tab_manager.getDisplayTotal` | `calcShopTotal(shop)` | なし |
| `bottom_summary._calculateCurrentShopTotal` | `calcShopTotal(widget.shop)` | **あり（修正）** |
| `existing_list_selector._calculateTotalPrice` | `calcShopTotal(shop, checkedOnly:false)` | **あり（修正）** |
| `item_edit_dialog._calculateTotal` | `calcItemTotalRaw(...)` | なし |
| `list_item_edit_dialog` | `calcItemTotalRaw(...)` | なし |
| `list_edit`（単価表示） | `calcDiscountedUnitPrice(...)` | なし |
| `ui_calculations.calcTotal` | **削除**（未使用デッドコード） | — |

> 単価表示（`list_edit`）と `priceWithTax` は数量を掛けないため per-unit 丸めが正しく、**値は変えていない**（式の置き場所のみ共通化）。

## 競合シナリオ
共有タブで2ユーザーが同時に同じ店を見ても、両者とも `calcShopTotal` 経由で同一値を算出するため、丸め起因のズレは構造的に発生しない。

## 完了条件
- [x] 丸め差を再現するユニットテスト（101円×50%引×3個 等）を追加し、全経路で同一値を返す
- [x] 重複していた計算式が共通関数の呼び出しに置換されている
- [x] 既存テスト（`shared_tab_manager_test.dart`, `list_item_test.dart`）がパス

## テスト
- 新規 `test/utils/calculation_utils_test.dart`（14件）
- `shared_tab_manager_test.dart` に #156 境界値回帰テストを追加
- `flutter analyze` エラー0 / `flutter test` 全431件パス

## 補足（別Issue化予定）
`main_screen.dart` の `includeTax` フィールドと税込トグル機能は現状どこからも参照されておらず完全にデッド。本PRのスコープ外とし、別途Issueで扱う。`ListItem.priceWithTax` は値を変えずに据え置き（import循環回避のためモデル層に残置）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
