### PR TITLE
fix(#154): ゲスト→ログイン移行失敗時のデータ永久消失を防止

### DIFF
--- a/lib/models/migration_result.dart
+++ b/lib/models/migration_result.dart
@@ -1,0 +1,55 @@
+// ゲスト→ログイン移行の結果を表す不変オブジェクト。
+// auth_provider と data_provider のどちらからも参照できるよう、
+// 業務ロジック層に依存しない models/ に配置する。
+
+/// ゲストデータの Firestore 移行結果。
+///
+/// 成功件数・失敗件数を保持し、呼び出し側（UI）が
+/// 「全件成功か」「一部失敗か」を判定して通知できるようにする。
+class MigrationResult {
+  const MigrationResult({
+    this.migratedShops = 0,
+    this.migratedItems = 0,
+    this.failedShops = 0,
+    this.failedItems = 0,
+  });
+
+  /// クラウドへ保存できたショップ数（今回実行分）
+  final int migratedShops;
+
+  /// クラウドへ保存できたアイテム数（今回実行分）
+  final int migratedItems;
+
+  /// 保存に失敗したショップ数
+  final int failedShops;
+
+  /// 保存に失敗したアイテム数
+  final int failedItems;
+
+  /// 移行対象が無く、何もしなかった結果。
+  static const MigrationResult empty = MigrationResult();
+
+  /// 失敗が1件も無い（全件成功）か。
+  bool get isComplete => failedShops == 0 && failedItems == 0;
+
+  /// 1件以上失敗したか。
+  bool get hasFailures => !isComplete;
+
+  /// 失敗した総件数（ショップ＋アイテム）。
+  int get failedCount => failedShops + failedItems;
+
+  /// 今回移行した総件数（ショップ＋アイテム）。
+  int get migratedCount => migratedShops + migratedItems;
+
+  /// 移行対象が存在せず、成功も失敗も無かったか。
+  bool get isNothingToMigrate =>
+      migratedShops == 0 &&
+      migratedItems == 0 &&
+      failedShops == 0 &&
+      failedItems == 0;
+
+  @override
+  String toString() =>
+      'MigrationResult(migratedShops: $migratedShops, migratedItems: $migratedItems, '
+      'failedShops: $failedShops, failedItems: $failedItems)';
+}

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -9,6 +9,7 @@ import 'package:maikago/services/one_time_purchase_service.dart';
 import 'package:maikago/services/feature_access_control.dart';
 import 'package:maikago/services/debug_service.dart';
 import 'package:maikago/services/settings_persistence.dart';
+import 'package:maikago/models/migration_result.dart';
 
 /// 認証状態の Provider。
 /// - 初期化時に現在ユーザー/監視をセットアップ
@@ -41,7 +42,11 @@ class AuthProvider extends ChangeNotifier {
   bool _isGuestMode = false;
 
   /// ゲスト→ログイン時のデータマイグレーションコールバック（DataProviderから設定）
-  Future<void> Function()? _onGuestDataMigration;
+  Future<MigrationResult> Function()? _onGuestDataMigration;
+
+  /// 直近のゲストデータ移行結果（UI がログイン後に通知判断するために参照）。
+  /// 一度参照したら [consumeLastMigrationResult] でクリアする。
+  MigrationResult? _lastMigrationResult;
 
   /// 画面表示制御用のローディングフラグ（初期化完了まで true）
   bool _isLoading = true; // 初期化中はtrueに変更
@@ -162,8 +167,17 @@ class AuthProvider extends ChangeNotifier {
 
   /// ゲスト→ログイン時のデータマイグレーションコールバックを設定
   /// （DataProviderのsetAuthProviderから呼ばれる）
-  void setGuestDataMigrationCallback(Future<void> Function() callback) {
+  void setGuestDataMigrationCallback(
+      Future<MigrationResult> Function() callback) {
     _onGuestDataMigration = callback;
+  }
+
+  /// 直近の移行結果を取り出してクリアする（UI 通知用、二重通知防止）。
+  /// 移行が走らなかった場合は null を返す。
+  MigrationResult? consumeLastMigrationResult() {
+    final result = _lastMigrationResult;
+    _lastMigrationResult = null;
+    return result;
   }
 
   /// ゲストモードに入る（ログインせずにアプリを使用）
@@ -190,10 +204,14 @@ class AuthProvider extends ChangeNotifier {
       if (wasGuestMode && _onGuestDataMigration != null) {
         try {
           DebugService().logInfo('ゲストデータのマイグレーション開始');
-          await _onGuestDataMigration!();
+          // 移行結果を保持し、UI 側が consumeLastMigrationResult() で
+          // 取り出して成功/一部失敗を通知できるようにする
+          _lastMigrationResult = await _onGuestDataMigration!();
         } catch (e) {
-          // マイグレーション失敗してもログイン自体は成功させる
+          // マイグレーション失敗してもログイン自体は成功させる。
+          // 例外時は詳細不明だが「失敗あり」として記録し、UI に通知させる。
           DebugService().logWarning('ゲストデータのマイグレーション失敗（ログインは継続）: $e');
+          _lastMigrationResult = const MigrationResult(failedShops: 1);
         }
       }
 

--- a/lib/providers/data_provider.dart
+++ b/lib/providers/data_provider.dart
@@ -118,8 +118,15 @@ class DataProvider extends ChangeNotifier {
 
   /// ログイン時のデータ読み込み後、移行し残したゲストデータがあれば自動救済する。
   /// 残データが無ければ [retryPendingGuestMigration] は即座に終了する（Issue #154）。
+  ///
+  /// 明示サインイン経路（auth_provider.signInWithGoogle）でも移行が走るため、
+  /// 新規サインイン時はこのリトライと二重に起動しうるが、移行は冪等かつ
+  /// [_guardedMigrate] で直列化されるため安全（残データ無しなら即終了）。
+  /// このリトライはアプリ再起動でセッション復元したときの救済が主目的。
+  /// loadData() が失敗してもリトライ救済を試みられるよう then ではなく
+  /// whenComplete で繋ぐ。
   void _loadDataAndRecoverGuestData() {
-    loadData().then((_) {
+    loadData().whenComplete(() {
       // 残ったゲストデータの再移行。失敗してもログインは継続する。
       retryPendingGuestMigration();
     });
@@ -403,55 +410,61 @@ class DataProvider extends ChangeNotifier {
     var migratedShops = 0;
     var migratedItems = 0;
 
-    // 4. ショップごとに保存し、紐づくアイテムを保存する
+    // 4. ショップを保存する（未移行のもののみ）。
+    // 新ID採番はクラウド既存データとの競合を回避するため。
     for (final shop in localShops) {
-      // 既に移行済みならクラウドIDを再利用、未移行なら新IDを採番。
-      // 新ID採番はクラウド既存データとの競合を回避するため。
-      var cloudShopId = shopIdMap[shop.id];
-
-      if (cloudShopId == null) {
-        cloudShopId = shop.id == '0'
-            ? '0' // デフォルトショップはID '0' のまま
-            : 'migrated_${shop.id}_${DateTime.now().millisecondsSinceEpoch}';
-        try {
-          final cloudShop = shop.copyWith(
-            id: cloudShopId,
-            createdAt: shop.createdAt ?? DateTime.now(),
-          );
-          await _dataService.saveShop(cloudShop, isAnonymous: false);
-          shopIdMap[shop.id] = cloudShopId;
-          migratedShops++;
-          // 成功のたびに進捗を永続化（途中で落ちても記録を残す）
-          await SettingsPersistence.saveMigrationProgress(
-              shopIdMap, migratedItemIds);
-        } catch (e) {
-          DebugService().logError('ショップ移行失敗: ${shop.name} - $e');
-          // ショップが作れないと配下アイテムも保存できないので次のショップへ。
-          // 失敗件数は末尾で「進捗に残っていないもの」として集計する。
-          continue;
-        }
+      if (shopIdMap.containsKey(shop.id)) {
+        continue; // 既に移行済み → 重複作成しない
       }
+      final cloudShopId = shop.id == '0'
+          ? '0' // デフォルトショップはID '0' のまま
+          : 'migrated_${shop.id}_${DateTime.now().millisecondsSinceEpoch}';
+      try {
+        final cloudShop = shop.copyWith(
+          id: cloudShopId,
+          createdAt: shop.createdAt ?? DateTime.now(),
+        );
+        await _dataService.saveShop(cloudShop, isAnonymous: false);
+        shopIdMap[shop.id] = cloudShopId;
+        migratedShops++;
+        // 成功のたびに進捗を永続化（途中で落ちても記録を残す）
+        await SettingsPersistence.saveMigrationProgress(
+            shopIdMap, migratedItemIds);
+      } catch (e) {
+        DebugService().logError('ショップ移行失敗: id=${shop.id} - $e');
+        // 失敗は末尾で「進捗に残っていないもの」として集計する。
+      }
+    }
 
-      // 5. ショップに紐づくアイテムを保存（移行済みはスキップ）
-      final shopItems =
-          localItems.where((item) => item.shopId == shop.id).toList();
-      for (final item in shopItems) {
-        if (migratedItemIds.contains(item.id)) {
-          continue; // 既に移行済み → 重複作成しない
-        }
-        try {
-          final cloudItem = item.copyWith(
-            shopId: cloudShopId,
-            createdAt: item.createdAt ?? DateTime.now(),
-          );
-          await _dataService.saveItem(cloudItem, isAnonymous: false);
-          migratedItemIds.add(item.id);
-          migratedItems++;
-          await SettingsPersistence.saveMigrationProgress(
-              shopIdMap, migratedItemIds);
-        } catch (e) {
-          DebugService().logError('アイテム移行失敗: ${item.name} - $e');
-        }
+    // 5. アイテムを保存する。
+    // 「属するショップがローカルに存在しない」orphan アイテム（ショップ削除後に
+    // 残ったアイテム等）も取りこぼさないよう、全アイテムを対象に走査する。
+    final localShopIds = localShops.map((s) => s.id).toSet();
+    for (final item in localItems) {
+      if (migratedItemIds.contains(item.id)) {
+        continue; // 既に移行済み → 重複作成しない
+      }
+      // 属するショップがローカルに在るのに今回移行できていない場合は、
+      // アイテムも保存できないので後回し（末尾で失敗集計→次回再試行）。
+      if (localShopIds.contains(item.shopId) &&
+          !shopIdMap.containsKey(item.shopId)) {
+        continue;
+      }
+      // 移行済みショップはクラウドIDへ。orphan は元のshopIdのまま保存し、
+      // ローカル状態を忠実に保持する（クラウドでも孤立アイテムとして残るが消えない）。
+      final cloudShopId = shopIdMap[item.shopId] ?? item.shopId;
+      try {
+        final cloudItem = item.copyWith(
+          shopId: cloudShopId,
+          createdAt: item.createdAt ?? DateTime.now(),
+        );
+        await _dataService.saveItem(cloudItem, isAnonymous: false);
+        migratedItemIds.add(item.id);
+        migratedItems++;
+        await SettingsPersistence.saveMigrationProgress(
+            shopIdMap, migratedItemIds);
+      } catch (e) {
+        DebugService().logError('アイテム移行失敗: id=${item.id} - $e');
       }
     }
 

--- a/lib/providers/data_provider.dart
+++ b/lib/providers/data_provider.dart
@@ -1,9 +1,9 @@
 // アプリの業務ロジック（一覧/編集/同期/共有合計）を集約し、UI層に通知
-import 'dart:async';
 import 'package:maikago/services/data_service.dart';
 import 'package:maikago/models/list.dart';
 import 'package:maikago/models/shop.dart';
 import 'package:maikago/models/sort_mode.dart';
+import 'package:maikago/models/migration_result.dart';
 import 'package:maikago/providers/auth_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:maikago/providers/data_provider_state.dart';
@@ -66,6 +66,9 @@ class DataProvider extends ChangeNotifier {
 
   bool _isLoading = false;
 
+  /// ゲストデータ移行の二重実行ガード（同時呼び出しで重複作成しないように）
+  bool _isMigrating = false;
+
   // --- 認証連携 ---
 
   void setAuthProvider(AuthProvider authProvider) {
@@ -89,7 +92,7 @@ class DataProvider extends ChangeNotifier {
         DebugService().logInfo('ログイン検出: データを完全にリセットして再読み込みします');
         if (!_isLoading) {
           _resetDataForLogin();
-          loadData();
+          _loadDataAndRecoverGuestData();
         }
       } else if (authProvider.isGuestMode) {
         DebugService().logInfo('ゲストモード検出: ローカルモードでデータを初期化');
@@ -106,11 +109,20 @@ class DataProvider extends ChangeNotifier {
     // 現在の認証状態に基づいてデータを読み込む
     if (authProvider.isLoggedIn && !authProvider.isLoading && !_isLoading) {
       _resetDataForLogin();
-      loadData();
+      _loadDataAndRecoverGuestData();
     } else if (authProvider.isGuestMode) {
       // アプリ起動時の復元: データクリアせずloadDataでローカルストレージから復元
       _initGuestMode(isRestoredSession: true);
     }
+  }
+
+  /// ログイン時のデータ読み込み後、移行し残したゲストデータがあれば自動救済する。
+  /// 残データが無ければ [retryPendingGuestMigration] は即座に終了する（Issue #154）。
+  void _loadDataAndRecoverGuestData() {
+    loadData().then((_) {
+      // 残ったゲストデータの再移行。失敗してもログインは継続する。
+      retryPendingGuestMigration();
+    });
   }
 
   void _resetDataForLogin() {
@@ -324,70 +336,151 @@ class DataProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// ゲストモードのローカルデータをFirestoreへマイグレーション
-  /// ログイン成功後、ゲストモード終了前に呼ばれる
-  Future<void> migrateGuestDataToCloud() async {
-    // 1. 現在のローカルデータをキャプチャ
-    final localShops = List<Shop>.from(_cacheManager.shops);
-    final localItems = List<ListItem>.from(_cacheManager.items);
+  /// ゲストモードのローカルデータをFirestoreへマイグレーション。
+  /// ログイン成功後、ゲストモード終了前に呼ばれる。
+  ///
+  /// 【Issue #154 の方針】
+  /// - 全件の保存成功を確認できた場合のみローカルのゲストデータをクリアする。
+  /// - 一部失敗時はローカルデータと移行進捗を残し、次回ログインで再試行する。
+  /// - 移行済みID（元ゲストID→クラウドID）の記録で再試行時の重複作成を防ぐ。
+  /// - 二重実行をガードする。
+  ///
+  /// 戻り値の [MigrationResult] で成功/一部失敗を呼び出し側（UI）に伝え、
+  /// 失敗時にユーザーへ通知できるようにする。
+  Future<MigrationResult> migrateGuestDataToCloud() {
+    return _guardedMigrate(() async {
+      // ゲストデータは SharedPreferences を正とする。
+      // ログイン処理中はキャッシュがリセットされる競合があり得るため、
+      // キャッシュではなく永続ストレージから移行対象を読み取る（Issue #154）。
+      final (localShops, localItems) =
+          await _cacheManager.readGuestDataFromStorage();
+      return _migrateData(localShops, localItems);
+    });
+  }
 
+  /// ログイン後、移行し残したゲストデータがあれば再移行する。
+  ///
+  /// ゲスト→ログイン移行が一部失敗したとき、ローカルに残ったデータを
+  /// 次回ログイン（アプリ起動）時に自動で救済するための入口（Issue #154）。
+  /// 残データが無ければ即座に空の結果を返すため、毎回のログインで呼んでも安全。
+  Future<MigrationResult> retryPendingGuestMigration() =>
+      migrateGuestDataToCloud();
+
+  /// 移行処理を二重実行ガードで包む共通ラッパー。
+  Future<MigrationResult> _guardedMigrate(
+      Future<MigrationResult> Function() body) async {
+    if (_isMigrating) {
+      DebugService().logWarning('マイグレーションが既に実行中のためスキップ');
+      return MigrationResult.empty;
+    }
+    _isMigrating = true;
+    try {
+      return await body();
+    } finally {
+      _isMigrating = false;
+    }
+  }
+
+  /// 渡されたショップ/アイテムを Firestore へ移行する中核処理。
+  /// 全件成功時のみゲストデータと移行進捗をクリアする。
+  Future<MigrationResult> _migrateData(
+      List<Shop> localShops, List<ListItem> localItems) async {
     if (localShops.isEmpty && localItems.isEmpty) {
-      return;
+      return MigrationResult.empty;
     }
 
     DebugService().logInfo(
         'マイグレーション開始: ショップ${localShops.length}件、アイテム${localItems.length}件');
 
-    // 2. ローカルモードをオフにしてFirestoreへの書き込みを有効化
+    // 2. これまでの移行進捗を読み込み（前回途中失敗分の再試行・重複防止）
+    final (shopIdMap, migratedItemIds) =
+        await SettingsPersistence.loadMigrationProgress();
+
+    // 3. ローカルモードをオフにしてFirestoreへの書き込みを有効化
     _cacheManager.setLocalMode(false);
     _state.shouldUseAnonymousSession = false;
 
-    try {
-      // 3. ショップをFirestoreに保存（デフォルトショップID '0' の競合を考慮）
-      for (final shop in localShops) {
+    var migratedShops = 0;
+    var migratedItems = 0;
+
+    // 4. ショップごとに保存し、紐づくアイテムを保存する
+    for (final shop in localShops) {
+      // 既に移行済みならクラウドIDを再利用、未移行なら新IDを採番。
+      // 新ID採番はクラウド既存データとの競合を回避するため。
+      var cloudShopId = shopIdMap[shop.id];
+
+      if (cloudShopId == null) {
+        cloudShopId = shop.id == '0'
+            ? '0' // デフォルトショップはID '0' のまま
+            : 'migrated_${shop.id}_${DateTime.now().millisecondsSinceEpoch}';
         try {
-          // 新しいIDでショップを作成（クラウドのデータとの競合を回避）
           final cloudShop = shop.copyWith(
-            id: shop.id == '0'
-                ? '0' // デフォルトショップはID '0' のまま
-                : 'migrated_${shop.id}_${DateTime.now().millisecondsSinceEpoch}',
+            id: cloudShopId,
             createdAt: shop.createdAt ?? DateTime.now(),
           );
-
-          await _dataService.saveShop(
-            cloudShop,
-            isAnonymous: false,
-          );
-
-          // 4. ショップに紐づくアイテムを保存（shopIdを更新）
-          final shopItems =
-              localItems.where((item) => item.shopId == shop.id).toList();
-          for (final item in shopItems) {
-            try {
-              final cloudItem = item.copyWith(
-                shopId: cloudShop.id,
-                createdAt: item.createdAt ?? DateTime.now(),
-              );
-              await _dataService.saveItem(
-                cloudItem,
-                isAnonymous: false,
-              );
-            } catch (e) {
-              DebugService().logError('アイテム移行失敗（スキップ）: ${item.name} - $e');
-            }
-          }
+          await _dataService.saveShop(cloudShop, isAnonymous: false);
+          shopIdMap[shop.id] = cloudShopId;
+          migratedShops++;
+          // 成功のたびに進捗を永続化（途中で落ちても記録を残す）
+          await SettingsPersistence.saveMigrationProgress(
+              shopIdMap, migratedItemIds);
         } catch (e) {
-          DebugService().logError('ショップ移行失敗（スキップ）: ${shop.name} - $e');
+          DebugService().logError('ショップ移行失敗: ${shop.name} - $e');
+          // ショップが作れないと配下アイテムも保存できないので次のショップへ。
+          // 失敗件数は末尾で「進捗に残っていないもの」として集計する。
+          continue;
         }
       }
 
-      // マイグレーション成功後、ローカルストレージのゲストデータをクリア
-      unawaited(SettingsPersistence.clearGuestData());
-      DebugService().logInfo('ゲストデータのFirestoreマイグレーション完了');
-    } catch (e) {
-      DebugService().logError('マイグレーション中にエラー: $e');
-      // マイグレーション失敗してもアプリは動作可能（データは失われる可能性あり）
+      // 5. ショップに紐づくアイテムを保存（移行済みはスキップ）
+      final shopItems =
+          localItems.where((item) => item.shopId == shop.id).toList();
+      for (final item in shopItems) {
+        if (migratedItemIds.contains(item.id)) {
+          continue; // 既に移行済み → 重複作成しない
+        }
+        try {
+          final cloudItem = item.copyWith(
+            shopId: cloudShopId,
+            createdAt: item.createdAt ?? DateTime.now(),
+          );
+          await _dataService.saveItem(cloudItem, isAnonymous: false);
+          migratedItemIds.add(item.id);
+          migratedItems++;
+          await SettingsPersistence.saveMigrationProgress(
+              shopIdMap, migratedItemIds);
+        } catch (e) {
+          DebugService().logError('アイテム移行失敗: ${item.name} - $e');
+        }
+      }
     }
+
+    // 6. 失敗件数は「移行進捗に残っていないもの」として集計する。
+    // こうすることで、保存できていないデータが1件でもあれば必ず失敗扱いになり、
+    // ローカルデータを誤って消すことがない（最優先原則: データを消さない）。
+    final failedShops =
+        localShops.where((s) => !shopIdMap.containsKey(s.id)).length;
+    final failedItems =
+        localItems.where((i) => !migratedItemIds.contains(i.id)).length;
+
+    final result = MigrationResult(
+      migratedShops: migratedShops,
+      migratedItems: migratedItems,
+      failedShops: failedShops,
+      failedItems: failedItems,
+    );
+
+    if (result.isComplete) {
+      // 全件成功したときのみローカルのゲストデータと進捗を破棄する
+      await SettingsPersistence.clearGuestData();
+      await SettingsPersistence.clearMigrationProgress();
+      DebugService().logInfo('ゲストデータのFirestoreマイグレーション完了: $result');
+    } else {
+      // 一部失敗：ローカルデータは残し、進捗を保持して次回ログインで再試行する
+      DebugService().logWarning('ゲストデータの移行が一部失敗（ローカルデータは保持）: $result');
+    }
+
+    return result;
   }
 
   void clearData() {

--- a/lib/providers/managers/data_cache_manager.dart
+++ b/lib/providers/managers/data_cache_manager.dart
@@ -132,6 +132,33 @@ class DataCacheManager {
     }
   }
 
+  /// SharedPreferences に残っているゲストデータを、キャッシュを変更せずに読み取る。
+  ///
+  /// ログイン後の移行リトライ（Issue #154）で、クラウド読み込み済みのキャッシュを
+  /// 壊さずに「移行し残したゲストデータ」だけを取り出すために使う。
+  Future<(List<Shop>, List<ListItem>)> readGuestDataFromStorage() async {
+    final items = <ListItem>[];
+    final shops = <Shop>[];
+    try {
+      final itemsJson = await SettingsPersistence.loadGuestItems();
+      if (itemsJson != null && itemsJson.isNotEmpty) {
+        final List<dynamic> itemsList = json.decode(itemsJson);
+        items.addAll(itemsList
+            .map((e) => ListItem.fromMap(Map<String, dynamic>.from(e))));
+      }
+
+      final shopsJson = await SettingsPersistence.loadGuestShops();
+      if (shopsJson != null && shopsJson.isNotEmpty) {
+        final List<dynamic> shopsList = json.decode(shopsJson);
+        shops.addAll(
+            shopsList.map((e) => Shop.fromMap(Map<String, dynamic>.from(e))));
+      }
+    } catch (e) {
+      DebugService().logError('ゲストデータ読み取りエラー: $e');
+    }
+    return (shops, items);
+  }
+
   /// 現在のキャッシュをSharedPreferencesに永続化（ローカルモード時のみ）
   void _persistToLocalStorage() {
     if (!_isLocalMode) return;

--- a/lib/screens/drawer/settings/account_screen.dart
+++ b/lib/screens/drawer/settings/account_screen.dart
@@ -239,12 +239,24 @@ class AccountScreen extends StatelessWidget {
 
   Future<void> _handleGoogleSignIn(BuildContext context) async {
     try {
-      final result = await context.read<AuthProvider>().signInWithGoogle();
+      final authProvider = context.read<AuthProvider>();
+      final result = await authProvider.signInWithGoogle();
       if (result == 'success' && context.mounted) {
+        // ゲストデータの移行結果を確認し、一部失敗していれば通知（Issue #154）。
+        final migration = authProvider.consumeLastMigrationResult();
         // ログイン成功時にデータを読み込み
         await context.read<DataProvider>().loadData();
         if (context.mounted) {
-          showSuccessSnackBar(context, 'ログインしました');
+          if (migration != null && migration.hasFailures) {
+            showWarningSnackBar(
+              context,
+              'お買い物リストの一部をクラウドに保存できませんでした。'
+              'データは端末に残っており、次回アプリ起動時に自動で再試行します。',
+              duration: const Duration(seconds: 6),
+            );
+          } else {
+            showSuccessSnackBar(context, 'ログインしました');
+          }
         }
       }
     } catch (e) {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -36,6 +36,17 @@ class _LoginScreenState extends State<LoginScreen> {
       if (!mounted) return;
 
       if (userCredential == 'success') {
+        // ゲストデータの移行結果を確認し、一部失敗していれば通知（Issue #154）。
+        // データは端末に残り、次回ログイン時に自動再試行される。
+        final migration = authProvider.consumeLastMigrationResult();
+        if (migration != null && migration.hasFailures) {
+          showWarningSnackBar(
+            context,
+            'お買い物リストの一部をクラウドに保存できませんでした。'
+            'データは端末に残っており、次回アプリ起動時に自動で再試行します。',
+            duration: const Duration(seconds: 6),
+          );
+        }
         widget.onLoginSuccess();
       } else if (userCredential == 'redirect') {
         // リダイレクト方式を使用（iOS PWA）

--- a/lib/services/settings_persistence.dart
+++ b/lib/services/settings_persistence.dart
@@ -18,6 +18,12 @@ class SettingsPersistence {
   static const String _strikethroughKey = 'strikethrough_on_completed_items';
   static const String _coachMarkCompletedKey = 'coach_mark_completed';
 
+  // ゲスト→ログイン移行の進捗（途中失敗からのリトライ・重複防止用）
+  // 元のゲストショップID → クラウドショップID のマップ（JSON）
+  static const String _migrationShopMapKey = 'guest_migration_shop_map';
+  // 移行済みアイテムの元ゲストID一覧（JSON配列）
+  static const String _migrationItemIdsKey = 'guest_migration_item_ids';
+
   // ── ジェネリックヘルパー ──────────────────────────────────
 
   /// SharedPreferencesに値を保存する汎用ヘルパー
@@ -324,6 +330,81 @@ class SettingsPersistence {
       ]);
     } catch (e) {
       DebugService().logError('clearGuestData エラー: $e');
+    }
+  }
+
+  // ── ゲスト→ログイン移行の進捗 ────────────────────────────
+  // 移行が途中失敗したときに「どこまで成功したか」を永続化し、
+  // 次回ログイン時の再試行で重複作成を防ぐために使う（Issue #154）。
+
+  /// 移行進捗を保存する。
+  ///
+  /// [shopIdMap] は「元ゲストショップID → クラウドショップID」のマップ。
+  /// [migratedItemIds] は移行済みアイテムの元ゲストID集合。
+  static Future<void> saveMigrationProgress(
+    Map<String, String> shopIdMap,
+    Set<String> migratedItemIds,
+  ) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await Future.wait([
+        prefs.setString(_migrationShopMapKey, jsonEncode(shopIdMap)),
+        prefs.setString(
+            _migrationItemIdsKey, jsonEncode(migratedItemIds.toList())),
+      ]);
+    } catch (e) {
+      DebugService().logError('saveMigrationProgress エラー: $e');
+    }
+  }
+
+  /// 移行進捗を読み込む。
+  ///
+  /// 戻り値は (shopIdMap, migratedItemIds) のレコード。
+  /// 進捗が無い・壊れている場合は空のマップ／集合を返す。
+  static Future<(Map<String, String>, Set<String>)>
+      loadMigrationProgress() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      final shopMap = <String, String>{};
+      final shopMapJson = prefs.getString(_migrationShopMapKey);
+      if (shopMapJson != null && shopMapJson.isNotEmpty) {
+        final decoded = jsonDecode(shopMapJson);
+        if (decoded is Map) {
+          decoded.forEach((key, value) {
+            shopMap[key.toString()] = value.toString();
+          });
+        }
+      }
+
+      final itemIds = <String>{};
+      final itemIdsJson = prefs.getString(_migrationItemIdsKey);
+      if (itemIdsJson != null && itemIdsJson.isNotEmpty) {
+        final decoded = jsonDecode(itemIdsJson);
+        if (decoded is List) {
+          for (final id in decoded) {
+            itemIds.add(id.toString());
+          }
+        }
+      }
+
+      return (shopMap, itemIds);
+    } catch (e) {
+      DebugService().logError('loadMigrationProgress エラー: $e');
+      return (<String, String>{}, <String>{});
+    }
+  }
+
+  /// 移行進捗をクリアする（全件成功して移行が完了したときに呼ぶ）。
+  static Future<void> clearMigrationProgress() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await Future.wait([
+        prefs.remove(_migrationShopMapKey),
+        prefs.remove(_migrationItemIdsKey),
+      ]);
+    } catch (e) {
+      DebugService().logError('clearMigrationProgress エラー: $e');
     }
   }
 

--- a/test/providers/auth_provider_test.dart
+++ b/test/providers/auth_provider_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:maikago/providers/auth_provider.dart';
+import 'package:maikago/models/migration_result.dart';
 import 'package:maikago/services/one_time_purchase_service.dart';
 import 'package:maikago/services/feature_access_control.dart';
 
@@ -184,6 +185,7 @@ void main() {
       var called = false;
       authProvider.setGuestDataMigrationCallback(() async {
         called = true;
+        return MigrationResult.empty;
       });
 
       // コールバックが設定されたことの間接確認

--- a/test/providers/data_provider_migration_test.dart
+++ b/test/providers/data_provider_migration_test.dart
@@ -1,0 +1,189 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:maikago/models/shop.dart';
+import 'package:maikago/providers/data_provider.dart';
+import 'package:maikago/services/settings_persistence.dart';
+import '../helpers/test_helpers.dart';
+import '../mocks.mocks.dart';
+
+/// Issue #154: ゲスト→ログイン移行の失敗時にローカルデータが永久消失する問題の
+/// 再発防止テスト。
+///
+/// 検証する不変条件:
+/// - 一部でも保存に失敗したらローカル（ゲスト）データを消さない
+/// - 再ログイン（再試行）で同じショップ/アイテムを重複作成しない
+/// - 全件成功したときだけゲストデータと移行進捗をクリアする
+///
+/// 移行対象は SharedPreferences のゲストデータ（guest_shops / guest_items）を正とする。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late DataProvider dataProvider;
+  late MockDataService mockDataService;
+
+  // 2ショップ・2アイテムのゲストデータを SharedPreferences に保存した状態を作る
+  void seedGuestStorageWithTwoShops() {
+    final shopA = createSampleShop(id: 'shopA', name: 'ショップA');
+    final shopB = createSampleShop(id: 'shopB', name: 'ショップB');
+    final itemA1 =
+        createSampleItem(id: 'itemA1', name: '商品A1', shopId: 'shopA');
+    final itemB1 =
+        createSampleItem(id: 'itemB1', name: '商品B1', shopId: 'shopB');
+
+    SharedPreferences.setMockInitialValues({
+      'is_guest_mode': true,
+      'guest_shops': jsonEncode([shopA.toMap(), shopB.toMap()]),
+      'guest_items': jsonEncode([itemA1.toMap(), itemB1.toMap()]),
+    });
+  }
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    mockDataService = MockDataService();
+    dataProvider = DataProvider(dataService: mockDataService);
+    dataProvider.setLocalMode(true);
+  });
+
+  group('migrateGuestDataToCloud - 全件成功', () {
+    test('全件成功時にゲストデータと移行進捗がクリアされる', () async {
+      seedGuestStorageWithTwoShops();
+
+      when(mockDataService.saveShop(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+      when(mockDataService.saveItem(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+
+      final result = await dataProvider.migrateGuestDataToCloud();
+
+      expect(result.isComplete, isTrue);
+      expect(result.hasFailures, isFalse);
+      expect(result.migratedShops, 2);
+      expect(result.migratedItems, 2);
+
+      // 全件成功 → ゲストデータは消えてよい
+      expect(await SettingsPersistence.loadGuestItems(), isNull);
+      expect(await SettingsPersistence.loadGuestShops(), isNull);
+      expect(await SettingsPersistence.loadGuestMode(), isFalse);
+
+      // 移行進捗もクリアされる
+      final (shopMap, itemIds) =
+          await SettingsPersistence.loadMigrationProgress();
+      expect(shopMap, isEmpty);
+      expect(itemIds, isEmpty);
+    });
+  });
+
+  group('migrateGuestDataToCloud - 一部失敗（データを消さない）', () {
+    test('ショップ保存が一部失敗するとゲストデータが残る', () async {
+      seedGuestStorageWithTwoShops();
+
+      // shopB の保存だけ失敗させる（ネットワーク遮断を模擬）
+      when(mockDataService.saveShop(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((invocation) async {
+        final shop = invocation.positionalArguments[0] as Shop;
+        if (shop.name == 'ショップB') {
+          throw Exception('network error');
+        }
+      });
+      when(mockDataService.saveItem(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+
+      final result = await dataProvider.migrateGuestDataToCloud();
+
+      expect(result.hasFailures, isTrue);
+      expect(result.failedShops, 1);
+      expect(result.failedItems, 1); // shopB 配下の商品B1も保存できていない
+
+      // ★最重要: 一部失敗時はゲストデータが残る（永久消失しない）
+      expect(await SettingsPersistence.loadGuestItems(), isNotNull);
+      expect(await SettingsPersistence.loadGuestShops(), isNotNull);
+      expect(await SettingsPersistence.loadGuestMode(), isTrue);
+
+      // 成功した shopA は進捗に記録され、次回再試行時にスキップできる
+      final (shopMap, itemIds) =
+          await SettingsPersistence.loadMigrationProgress();
+      expect(shopMap.containsKey('shopA'), isTrue);
+      expect(shopMap.containsKey('shopB'), isFalse);
+      expect(itemIds.contains('itemA1'), isTrue);
+    });
+
+    test('アイテム保存が失敗してもゲストデータが残る', () async {
+      seedGuestStorageWithTwoShops();
+
+      when(mockDataService.saveShop(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+      // 全アイテムの保存を失敗させる
+      when(mockDataService.saveItem(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenThrow(Exception('network error'));
+
+      final result = await dataProvider.migrateGuestDataToCloud();
+
+      expect(result.hasFailures, isTrue);
+      expect(result.failedItems, 2);
+
+      // アイテムが1件でも保存できていなければゲストデータは残す
+      expect(await SettingsPersistence.loadGuestItems(), isNotNull);
+      expect(await SettingsPersistence.loadGuestShops(), isNotNull);
+    });
+  });
+
+  group('migrateGuestDataToCloud - 冪等性（再ログインで重複しない）', () {
+    test('再試行時に成功済みのショップ/アイテムを重複作成しない', () async {
+      seedGuestStorageWithTwoShops();
+
+      var shopBShouldFail = true;
+      when(mockDataService.saveShop(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((invocation) async {
+        final shop = invocation.positionalArguments[0] as Shop;
+        if (shop.name == 'ショップB' && shopBShouldFail) {
+          throw Exception('network error');
+        }
+      });
+      when(mockDataService.saveItem(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+
+      // 1回目: shopB が失敗 → 一部失敗
+      final firstResult = await dataProvider.migrateGuestDataToCloud();
+      expect(firstResult.hasFailures, isTrue);
+
+      // 2回目（再ログイン相当）: ネットワーク回復で shopB も成功
+      shopBShouldFail = false;
+      final secondResult = await dataProvider.retryPendingGuestMigration();
+      expect(secondResult.isComplete, isTrue);
+
+      // saveShop の全呼び出しを検証: shopA は1回だけ（重複なし）、shopB は2回（失敗→再試行）
+      final capturedShops = verify(
+        mockDataService.saveShop(
+          captureAny,
+          isAnonymous: anyNamed('isAnonymous'),
+        ),
+      ).captured.cast<Shop>();
+      final shopACalls = capturedShops.where((s) => s.name == 'ショップA').length;
+      final shopBCalls = capturedShops.where((s) => s.name == 'ショップB').length;
+      expect(shopACalls, 1, reason: '成功済みショップAを再保存してはいけない');
+      expect(shopBCalls, 2, reason: '失敗したショップBのみ再試行する');
+
+      // 全件成功 → ゲストデータと進捗がクリアされる
+      expect(await SettingsPersistence.loadGuestItems(), isNull);
+      final (shopMap, itemIds) =
+          await SettingsPersistence.loadMigrationProgress();
+      expect(shopMap, isEmpty);
+      expect(itemIds, isEmpty);
+    });
+  });
+
+  group('migrateGuestDataToCloud - 対象なし', () {
+    test('ゲストデータが空なら何もしない', () async {
+      SharedPreferences.setMockInitialValues({});
+
+      final result = await dataProvider.migrateGuestDataToCloud();
+
+      expect(result.isNothingToMigrate, isTrue);
+      verifyNever(
+          mockDataService.saveShop(any, isAnonymous: anyNamed('isAnonymous')));
+    });
+  });
+}

--- a/test/providers/data_provider_migration_test.dart
+++ b/test/providers/data_provider_migration_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:maikago/models/shop.dart';
+import 'package:maikago/models/list.dart';
 import 'package:maikago/providers/data_provider.dart';
 import 'package:maikago/services/settings_persistence.dart';
 import '../helpers/test_helpers.dart';
@@ -172,6 +173,45 @@ void main() {
           await SettingsPersistence.loadMigrationProgress();
       expect(shopMap, isEmpty);
       expect(itemIds, isEmpty);
+    });
+  });
+
+  group('migrateGuestDataToCloud - orphanアイテム（永久スタック防止）', () {
+    test('属するショップが存在しないorphanアイテムも移行され、完了できる', () async {
+      // shopA は存在するが、deletedShop は存在しない（ショップ削除後に残ったアイテムを模擬）
+      final shopA = createSampleShop(id: 'shopA', name: 'ショップA');
+      final itemA1 =
+          createSampleItem(id: 'itemA1', name: '商品A1', shopId: 'shopA');
+      final orphan =
+          createSampleItem(id: 'orphan1', name: '孤立商品', shopId: 'deletedShop');
+
+      SharedPreferences.setMockInitialValues({
+        'is_guest_mode': true,
+        'guest_shops': jsonEncode([shopA.toMap()]),
+        'guest_items': jsonEncode([itemA1.toMap(), orphan.toMap()]),
+      });
+
+      when(mockDataService.saveShop(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+      when(mockDataService.saveItem(any, isAnonymous: anyNamed('isAnonymous')))
+          .thenAnswer((_) async {});
+
+      final result = await dataProvider.migrateGuestDataToCloud();
+
+      // orphan を取りこぼさず全件成功でき、毎回警告が出続けるスタックに陥らない
+      expect(result.isComplete, isTrue, reason: 'orphanアイテムで永久未完了になってはいけない');
+      expect(result.migratedItems, 2);
+
+      // orphan は元の shopId を保ったまま保存される（ローカル状態を忠実に保持）
+      final savedItems = verify(
+        mockDataService.saveItem(captureAny,
+            isAnonymous: anyNamed('isAnonymous')),
+      ).captured.cast<ListItem>();
+      final savedOrphan = savedItems.firstWhere((i) => i.id == 'orphan1');
+      expect(savedOrphan.shopId, 'deletedShop');
+
+      // 全件成功 → ゲストデータがクリアされる
+      expect(await SettingsPersistence.loadGuestItems(), isNull);
     });
   });
 


### PR DESCRIPTION
## 概要
Issue #154 を解決。ゲスト→ログイン移行が失敗したときにローカルデータが永久消失する問題を修正。

## 原因
`migrateGuestDataToCloud()` が個別の保存失敗を握りつぶして続行し、ループ後に**無条件で** `clearGuestData()` を実行していたため、クラウドにもローカルにも残らないデータが発生していた。再ログイン時の重複作成・移行失敗の無通知・二重実行ガードの欠如も合わせて修正。

## 変更内容
- **全件成功時のみクリア**: 失敗件数を「移行進捗に残っていないもの」で集計し、1件でも未保存ならゲストデータを残す（最優先原則: データを消さない）
- **冪等化**: 移行済みID（元ゲストID→クラウドID のマップ）を SharedPreferences に永続化。再試行時は済みをスキップし重複を防止
- **移行元の堅牢化**: ログイン処理中にキャッシュがリセットされる競合に対応するため、移行元をキャッシュから SharedPreferences（確実な保存元）に変更
- **自動再試行**: ログイン後（アプリ起動時のログイン検出含む）に残データの再移行を発火。残データが無ければ即終了
- **二重実行ガード**: 同時呼び出しによる重複作成を防止
- **失敗通知**: `MigrationResult` を返し、`login_screen` / `account_screen` で一部失敗を SnackBar 通知

## 変更ファイル
| ファイル | 内容 |
|---|---|
| `lib/models/migration_result.dart`（新規） | 移行結果（成功/失敗件数） |
| `lib/services/settings_persistence.dart` | 移行進捗の保存/読込/クリア |
| `lib/providers/data_provider.dart` | 移行の冪等化・全件成功時のみクリア・自動再試行 |
| `lib/providers/managers/data_cache_manager.dart` | ゲストデータの読み取り専用メソッド |
| `lib/providers/auth_provider.dart` | コールバック戻り値を MigrationResult 化・結果保持 |
| `lib/screens/login_screen.dart` / `account_screen.dart` | 失敗時の SnackBar 通知 |
| `test/providers/data_provider_migration_test.dart`（新規） | 失敗系・冪等性テスト5件 |

## テスト
- [x] flutter analyze 通過（0件）
- [x] flutter test 通過（413件 / integration除く）
- [x] 途中失敗でローカルデータが残るテスト（ショップ失敗・アイテム失敗）
- [x] 再ログインでショップ/アイテムが重複しないテスト（冪等性）
- [ ] コードレビュー（code-reviewプラグイン）
- [ ] 実機動作確認

## Issue 完了条件
- [x] 移行途中でネットワークを遮断してもローカルデータが消えない（テスト確認）
- [x] 再ログイン時にショップ/アイテムが重複しない（テスト確認）
- [x] 移行失敗時にユーザーへ通知が表示される
- [x] flutter analyze / flutter test がパス

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
