### PR TITLE
fix(#162): Firestoreルールの共有メンバー判定を人数無制限化

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -38,5 +38,14 @@
   },
   "functions": {
     "source": "functions"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": false
+    },
+    "singleProjectMode": true
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -67,19 +67,14 @@ service cloud.firestore {
         request.resource.data.ownerId == request.auth.uid &&
         request.resource.data.ownerId is string;
 
-      // 読み取り：メンバーまたはオーナーのみ
-      allow read: if request.auth != null && (
-        resource.data.ownerId == request.auth.uid ||
-        (resource.data.members != null && resource.data.members[request.auth.uid] != null) ||
-        (resource.data.members != null && isMemberInArray(resource.data.members, request.auth.uid))
-      );
+      // 読み取り：メンバーまたはオーナーのみ（人数無制限の memberIds 判定に集約）
+      allow read: if request.auth != null &&
+        isFamilyMember(resource.data, request.auth.uid);
 
       // 更新：メンバー、オーナー、または新規メンバー追加時
       allow update: if request.auth != null && (
-        // 既存メンバーまたはオーナー
-        (resource.data.members != null && resource.data.members[request.auth.uid] != null) ||
-        resource.data.ownerId == request.auth.uid ||
-        (resource.data.members != null && isMemberInArray(resource.data.members, request.auth.uid)) ||
+        // 既存メンバーまたはオーナー（人数無制限の memberIds 判定に集約）
+        isFamilyMember(resource.data, request.auth.uid) ||
         // 新しいメンバーが自分自身を追加する場合（招待承認時）
         // members配列のサイズが1つ増え、新しいメンバーが自分自身である場合
         (request.resource.data.members.size() == resource.data.members.size() + 1 &&
@@ -95,10 +90,26 @@ service cloud.firestore {
       allow delete: if request.auth != null &&
         resource.data.ownerId == request.auth.uid;
 
-      // ヘルパー関数：メンバー配列にユーザーが存在するかチェック
-      // TODO: membersフィールドのデータ構造がArray（Mapのリスト）とMap（UIDをキー）で不統一。
-      // 将来的にMap形式に統一し、この関数を不要にすることを推奨。
-      // 現在は既存データとの互換性のため、Arrayチェック（最大10人）とMapチェックの両方を維持。
+      // ヘルパー関数：ファミリーのメンバー（またはオーナー）かどうかを判定する。
+      // 判定の優先順位：
+      //   1. オーナー
+      //   2. memberIds（UID文字列の配列）に含まれる   ← 人数無制限。Issue #162 の本命
+      //   3. members が Map（UIDキー）形式            ← 人数無制限
+      //   4. members が Array（Mapのリスト）形式       ← 旧データ互換。最大10人（isMemberInArray）
+      // memberIds を持つ新しいデータは人数無制限で判定でき、
+      // memberIds を持たない旧データは従来どおり 3/4 のフォールバックで判定する（回帰なし）。
+      // Map.get(key, default) でフィールド欠如時のエラーを防ぎ、is list / is map で型不一致エラーを防ぐ。
+      function isFamilyMember(data, userId) {
+        return data.ownerId == userId ||
+          (data.get('memberIds', []) is list && userId in data.get('memberIds', [])) ||
+          (data.get('members', []) is map && data.get('members', [])[userId] != null) ||
+          (data.get('members', []) is list && isMemberInArray(data.get('members', []), userId));
+      }
+
+      // ヘルパー関数：メンバー配列（Mapのリスト）にユーザーが存在するかチェック（旧データ互換・最大10人）
+      // TODO: Issue #162 — 旧 Array 形式の上限10人はこの関数の構造的制約。
+      // 新データは memberIds（UID配列）で人数無制限に判定する（isFamilyMember 参照）。
+      // 旧データが一掃されたらこの関数は削除可能。
       function isMemberInArray(members, userId) {
         return members.size() > 0 && (
           (members.size() > 0 && members[0] is map && members[0].id == userId) ||

--- a/firestore.rules
+++ b/firestore.rules
@@ -99,10 +99,16 @@ service cloud.firestore {
       // memberIds を持つ新しいデータは人数無制限で判定でき、
       // memberIds を持たない旧データは従来どおり 3/4 のフォールバックで判定する（回帰なし）。
       // Map.get(key, default) でフィールド欠如時のエラーを防ぎ、is list / is map で型不一致エラーを防ぐ。
+      //
+      // ⚠ memberIds は members から派生する非正規化フィールド。members を変更する書き込みは
+      //   memberIds も同時に更新しないとズレる（削除済みメンバーが memberIds 経由で読み続ける恐れ）。
+      //   現状 members を作成後に変更する経路はクライアント未実装のため未発生。
+      //   将来 add/remove を実装する際は、書き込み側または onDocumentUpdated トリガで
+      //   memberIds の同期を必ず用意すること（書き込み側の堅牢化は Issue #198 で追跡）。
       function isFamilyMember(data, userId) {
         return data.ownerId == userId ||
           (data.get('memberIds', []) is list && userId in data.get('memberIds', [])) ||
-          (data.get('members', []) is map && data.get('members', [])[userId] != null) ||
+          (data.get('members', {}) is map && userId in data.get('members', {})) ||
           (data.get('members', []) is list && isMemberInArray(data.get('members', []), userId));
       }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -273,7 +273,8 @@ exports.applyFamilyPlanToGroup = onDocumentCreated(
     // Issue #162: Firestoreルールの人数無制限メンバー判定（isFamilyMember）のため、
     // UID文字列の配列 memberIds をファミリードキュメントに付与する。
     // これにより11人目以降のメンバーも共有データを読めるようになる。
-    const memberIds = members.map((m) => m.id).filter(Boolean);
+    // 壊れた1件（null要素・id欠如）で関数全体が落ちないよう、要素単位で防御する。
+    const memberIds = members.filter((m) => m && m.id).map((m) => m.id);
     const batch = admin.firestore().batch();
 
     try {

--- a/functions/index.js
+++ b/functions/index.js
@@ -270,9 +270,18 @@ exports.applyFamilyPlanToGroup = onDocumentCreated(
     if (!familyData) return null;
 
     const members = familyData.members || [];
+    // Issue #162: Firestoreルールの人数無制限メンバー判定（isFamilyMember）のため、
+    // UID文字列の配列 memberIds をファミリードキュメントに付与する。
+    // これにより11人目以降のメンバーも共有データを読めるようになる。
+    const memberIds = members.map((m) => m.id).filter(Boolean);
     const batch = admin.firestore().batch();
 
     try {
+      // ファミリードキュメント自身に memberIds を書き戻す（既存メンバー配列はそのまま温存）
+      if (event.data?.ref) {
+        batch.set(event.data.ref, { memberIds }, { merge: true });
+      }
+
       for (const m of members) {
         const uid = m.id;
         if (!uid) continue;
@@ -281,7 +290,7 @@ exports.applyFamilyPlanToGroup = onDocumentCreated(
           planType: 'family',
           isActive: true,
           expiryDate: null,
-          familyMembers: members.map(x => x.id),
+          familyMembers: memberIds,
           updatedAt: admin.firestore.FieldValue.serverTimestamp(),
         }, { merge: true });
       }

--- a/test/firestore_rules/.gitignore
+++ b/test/firestore_rules/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+package-lock.json
+firebase-debug.log
+firestore-debug.log
+ui-debug.log

--- a/test/firestore_rules/.mocharc.json
+++ b/test/firestore_rules/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "spec": "*.test.js",
+  "timeout": 20000
+}

--- a/test/firestore_rules/README.md
+++ b/test/firestore_rules/README.md
@@ -1,0 +1,44 @@
+# Firestore セキュリティルールの emulator テスト
+
+`firestore.rules` の挙動を Firebase エミュレータ上で検証するユニットテスト。
+Flutter の `flutter test`（Dart）とは別系統で、Node.js + `@firebase/rules-unit-testing` を使う。
+
+## 対象
+
+- `families/{familyId}` の読み取り/更新メンバー判定（Issue #162）
+  - `memberIds`（UID文字列の配列）による人数無制限のメンバー判定
+  - 旧データ（配列形式・最大10人）の回帰がないこと
+
+## 前提
+
+- Node.js 18 以上
+- **JDK 21 以上**（Firestore エミュレータの実行に必要。`firebase-tools` 15 系の要件）
+  - 例: `JAVA_HOME` を JDK 21+ に向ける
+
+## 実行方法
+
+```bash
+cd test/firestore_rules
+npm install
+
+# エミュレータを起動してテストを実行（推奨）
+npm run test:emulator
+```
+
+`test:emulator` は `firebase emulators:exec` で Firestore エミュレータを一時起動し、
+その中で `npm test`（mocha）を実行する。リポジトリルートの `firebase.json` の
+`firestore.rules` と `emulators.firestore`（ポート 8080）を使用する。
+
+### 既にエミュレータが起動している場合
+
+別途 `firebase emulators:start --only firestore` 済みなら、テストだけ実行できる:
+
+```bash
+cd test/firestore_rules
+npm test
+```
+
+## メモ
+
+- `node_modules/` と `package-lock.json` は `.gitignore` 済み。
+- CI への組み込みは未対応（Issue #165 のワークフロー整備時に検討）。

--- a/test/firestore_rules/families.rules.test.js
+++ b/test/firestore_rules/families.rules.test.js
@@ -1,0 +1,110 @@
+// Firestore セキュリティルールの emulator ユニットテスト
+//
+// 対象: firestore.rules の families/{familyId} の読み取り/更新メンバー判定
+// 背景 Issue #162: メンバー判定が members[0]〜members[9] の10人ハードコードで、
+//   11人目以降が共有データを読めなかった。
+//   修正後は memberIds（UID文字列の配列）で人数無制限に判定できることを検証する。
+//   旧データ（memberIds なし・配列形式 <=10人）の既存メンバーが回帰しないことも検証する。
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  initializeTestEnvironment,
+  assertSucceeds,
+  assertFails,
+} from '@firebase/rules-unit-testing';
+import { doc, getDoc, setDoc } from 'firebase/firestore';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// firestore.rules はリポジトリルートにある（このファイルから2階層上）
+const RULES = readFileSync(join(__dirname, '..', '..', 'firestore.rules'), 'utf8');
+
+const PROJECT_ID = 'demo-maikago-rules';
+
+let testEnv;
+
+// 配列形式のメンバー（[{id, name}, ...]）を n 件生成
+function makeMembers(n) {
+  return Array.from({ length: n }, (_, i) => ({ id: `u${i}`, name: `member${i}` }));
+}
+
+// ルールを無効化した管理者コンテキストで families ドキュメントを作成（テストデータ投入用）
+async function seedFamily(familyId, data) {
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), 'families', familyId), data);
+  });
+}
+
+function readAs(uid, familyId) {
+  const db = testEnv.authenticatedContext(uid).firestore();
+  return getDoc(doc(db, 'families', familyId));
+}
+
+before(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: PROJECT_ID,
+    firestore: {
+      rules: RULES,
+      host: '127.0.0.1',
+      port: 8080,
+    },
+  });
+});
+
+after(async () => {
+  if (testEnv) await testEnv.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+describe('families の読み取り権限', () => {
+  it('オーナーは読める', async () => {
+    await seedFamily('f-owner', { ownerId: 'owner', members: [], memberIds: [] });
+    await assertSucceeds(readAs('owner', 'f-owner'));
+  });
+
+  it('memberIds に含まれる11人目が読める（Issue #162 の本丸）', async () => {
+    const members = makeMembers(11); // u0..u10
+    await seedFamily('f-11', {
+      ownerId: 'owner',
+      members,
+      memberIds: members.map((m) => m.id),
+    });
+    // u10 = 11人目。旧ルールでは members[10] を見ていないため拒否されていた。
+    await assertSucceeds(readAs('u10', 'f-11'));
+  });
+
+  it('memberIds 形式で非メンバーは読めない', async () => {
+    const members = makeMembers(3);
+    await seedFamily('f-stranger', {
+      ownerId: 'owner',
+      members,
+      memberIds: members.map((m) => m.id),
+    });
+    await assertFails(readAs('stranger', 'f-stranger'));
+  });
+
+  it('回帰防止: 旧配列形式（memberIds なし・10人）の10人目が読める', async () => {
+    const members = makeMembers(10); // u0..u9
+    await seedFamily('f-legacy-10', { ownerId: 'owner', members }); // memberIds なし
+    await assertSucceeds(readAs('u9', 'f-legacy-10')); // 10人目
+  });
+
+  it('回帰防止: 旧配列形式（memberIds なし）の非メンバーは読めない', async () => {
+    const members = makeMembers(5);
+    await seedFamily('f-legacy-deny', { ownerId: 'owner', members });
+    await assertFails(readAs('stranger', 'f-legacy-deny'));
+  });
+
+  it('境界: 旧配列形式のみ（memberIds なし・11人）では11人目は読めない（既知の制限の固定）', async () => {
+    const members = makeMembers(11); // u0..u10
+    await seedFamily('f-legacy-11', { ownerId: 'owner', members }); // memberIds なし
+    // memberIds が無い旧データでは、配列ハードコードの制限により11人目は読めないまま。
+    // → 11人目を救うには memberIds を持たせること、という修正方針を固定する。
+    await assertFails(readAs('u10', 'f-legacy-11'));
+  });
+});

--- a/test/firestore_rules/families.rules.test.js
+++ b/test/firestore_rules/families.rules.test.js
@@ -100,6 +100,28 @@ describe('families の読み取り権限', () => {
     await assertFails(readAs('stranger', 'f-legacy-deny'));
   });
 
+  it('Map形式（UIDキー）の members でもメンバーは読める', async () => {
+    // members が「UIDをキーにした Map」形式のデータ。isFamilyMember の case 3 を検証。
+    await seedFamily('f-map', {
+      ownerId: 'owner',
+      members: { u0: { name: 'm0' }, u1: { name: 'm1' } },
+    });
+    await assertSucceeds(readAs('u1', 'f-map'));
+    await assertFails(readAs('stranger', 'f-map'));
+  });
+
+  it('壊れデータ: memberIds が配列でない（文字列）場合でも評価エラーで誤判定しない', async () => {
+    // is list ガードにより memberIds 判定はスキップされ、members 配列フォールバックで判定される。
+    const members = makeMembers(3); // u0..u2
+    await seedFamily('f-broken', {
+      ownerId: 'owner',
+      members,
+      memberIds: 'garbage', // 非配列の壊れた値
+    });
+    await assertSucceeds(readAs('u1', 'f-broken')); // members 配列で救済
+    await assertFails(readAs('stranger', 'f-broken'));
+  });
+
   it('境界: 旧配列形式のみ（memberIds なし・11人）では11人目は読めない（既知の制限の固定）', async () => {
     const members = makeMembers(11); // u0..u10
     await seedFamily('f-legacy-11', { ownerId: 'owner', members }); // memberIds なし

--- a/test/firestore_rules/package.json
+++ b/test/firestore_rules/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "maikago-firestore-rules-tests",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Firestore セキュリティルールの emulator ユニットテスト（families の共有メンバー判定など）",
+  "scripts": {
+    "test": "mocha",
+    "test:emulator": "firebase emulators:exec --only firestore --project=demo-maikago --config=../../firebase.json \"npm test\""
+  },
+  "devDependencies": {
+    "@firebase/rules-unit-testing": "^3.0.4",
+    "firebase": "^10.14.1",
+    "mocha": "^10.8.2"
+  }
+}


### PR DESCRIPTION
## 概要

Issue #162 を解決。Firestore ルールの共有メンバー判定が `members[0]`〜`members[9]` の10人ハードコードになっており、共有グループの **11人目以降が共有データを読めなかった**問題を修正する。

## 原因

`firestore.rules` の `isMemberInArray()` が、メンバー配列を `members[0]`〜`members[9]` と10個分だけ手書きでチェックしていた。Firestore ルールにはループが無いため配列の各要素を順に調べられず、11番目（`members[10]`）を見る行が存在しなかった。

## 変更内容

- **`firestore.rules`**
  - `families/{familyId}` の read / update のメンバー判定を `isFamilyMember()` ヘルパーに集約。
  - 判定優先順位: ①オーナー → ②`memberIds`（UID文字列の配列・**人数無制限**） → ③`members` が Map（UIDキー）形式 → ④`members` が Array（Mapのリスト）形式（旧データ互換・最大10人）。
  - `Map.get(key, default)` と `is list` / `is map` でフィールド欠如・型不一致のエラーを防止（従来の error-absorption 依存を解消）。
- **`functions/index.js`**
  - `applyFamilyPlanToGroup`（family 作成トリガー）で `memberIds` を family ドキュメントに書き戻し。新規 family は最初から人数無制限対応になる。
- **`firebase.json`**
  - Firestore emulator 設定を追加（ルールテスト実行用・additive）。
- **`test/firestore_rules/`（新規）**
  - `@firebase/rules-unit-testing` による emulator ルールテスト基盤と6テストを追加。

## テスト

emulator ルールテスト（`test/firestore_rules/`・6件すべて green）:

- [x] memberIds に含まれる **11人目が読める**（Issue #162 の本丸 / 修正前は失敗を確認済み）
- [x] memberIds 形式で非メンバーは読めない
- [x] 回帰防止: 旧配列形式（memberIds なし・10人）の10人目が読める
- [x] 回帰防止: 旧配列形式の非メンバーは読めない
- [x] 境界: 旧配列形式のみ（11人）では11人目は読めない（既知の制限の固定）
- [x] オーナーは読める

その他:

- [x] `flutter analyze` 通過（エラー0）
- [x] `flutter test` 通過（449件）

## 完了条件

- [x] 11人目のメンバーが共有データを読める（`memberIds` 経由・emulator テストで実証）
- [x] Firestore emulator でのルールテストが追加されている
- [x] 既存メンバーのアクセスに回帰がない（旧形式の回帰テスト + 全 Flutter テスト通過）

## 補足・残課題

- **データ移行なし**: `memberIds` は追加フィールド。本番データへの破壊的変更はない。旧データは `memberIds` 無しでもフォールバックで動作する。
- **デプロイ**: `firestore.rules` / `functions` の本番反映（`firebase deploy`）はマージ後に別途必要。
- **残る境界**: 旧 Array 形式での「自分を11人目として追加（招待承認）」フローは `isMemberInArray`（最大10）のまま。完了条件の「読めること」は満たすが、>10人の**追加**フローは将来のクライアント実装時に `memberIds` を維持する対応が必要。
- **CI**: rules テストは Node/emulator 系のため、現行 CI ゲート（`flutter test`）とは別系統。CI 組み込みは Issue #165 のワークフロー整備時に検討。

Closes #162
