### PR TITLE
fix(#159): 共有タブのグループ更新をWriteBatchで原子化し途中失敗をロールバック

### DIFF
--- a/lib/providers/managers/shared_tab_manager.dart
+++ b/lib/providers/managers/shared_tab_manager.dart
@@ -72,6 +72,14 @@ class SharedTabManager {
     final removedTabIds =
         previousSharedTabs.where((id) => !selectedTabIds.contains(id)).toList();
 
+    // Issue #159: 失敗時に巻き戻すため、関係ショップの更新前状態を退避する
+    final involvedIds = <String>{
+      shopId,
+      ...selectedTabIds,
+      ...previousSharedTabs
+    };
+    final originalById = _snapshot(involvedIds);
+
     final updatedShop = currentShop.copyWith(
       name: name ?? currentShop.name,
       sharedTabs: selectedTabIds,
@@ -133,39 +141,28 @@ class SharedTabManager {
     _state.notifyListeners();
 
     if (!_cacheManager.isLocalMode) {
+      // 更新対象（自身 + 解除タブ + 選択タブ）を集めて1回のバッチで保存する
+      final idsToPersist = <String>{
+        shopId,
+        ...removedTabIds,
+        ...selectedTabIds
+      };
+      final shopsToPersist = _collectShops(idsToPersist);
+
       try {
-        await _dataService.updateShop(
-          updatedShop,
+        await _dataService.updateShopsBatch(
+          shopsToPersist,
           isAnonymous: _state.shouldUseAnonymousSession,
         );
-
-        for (final removedTabId in removedTabIds) {
-          final removedTabIndex =
-              _cacheManager.shops.indexWhere((shop) => shop.id == removedTabId);
-          if (removedTabIndex != -1) {
-            await _dataService.updateShop(
-              _cacheManager.shops[removedTabIndex],
-              isAnonymous: _state.shouldUseAnonymousSession,
-            );
-          }
-        }
-
-        for (final tabId in selectedTabIds) {
-          final tabIndex =
-              _cacheManager.shops.indexWhere((shop) => shop.id == tabId);
-          if (tabIndex != -1) {
-            await _dataService.updateShop(
-              _cacheManager.shops[tabIndex],
-              isAnonymous: _state.shouldUseAnonymousSession,
-            );
-          }
-        }
 
         _state.isSynced = true;
         DebugService().logInfo('共有タブ更新完了: ショップID=$shopId');
       } catch (e) {
         _state.isSynced = false;
         DebugService().logError('共有タブ更新エラー: $e');
+        // Issue #159: 途中失敗時は全ショップを更新前へ巻き戻す
+        _rollback(originalById, involvedIds);
+        _state.notifyListeners();
         rethrow;
       }
     }
@@ -188,6 +185,15 @@ class SharedTabManager {
         }
       }
     }
+
+    // Issue #159: 失敗時に巻き戻すため、関係ショップの更新前状態を退避する
+    final involvedIds = <String>{shopId};
+    for (final shop in _cacheManager.shops) {
+      if (shop.id != shopId && shop.sharedTabs.contains(shopId)) {
+        involvedIds.add(shop.id);
+      }
+    }
+    final originalById = _snapshot(involvedIds);
 
     final updatedShop = currentShop.copyWith(
       name: name ?? currentShop.name,
@@ -218,27 +224,24 @@ class SharedTabManager {
     _state.notifyListeners();
 
     if (!_cacheManager.isLocalMode) {
+      // 離脱ショップ + 参照を外した関係ショップを1回のバッチで保存する
+      final idsToPersist = <String>{shopId, ...affectedShopIds};
+      final shopsToPersist = _collectShops(idsToPersist);
+
       try {
-        await _dataService.updateShop(
-          updatedShop,
+        await _dataService.updateShopsBatch(
+          shopsToPersist,
           isAnonymous: _state.shouldUseAnonymousSession,
         );
-
-        for (final affectedId in affectedShopIds) {
-          final affectedIndex =
-              _cacheManager.shops.indexWhere((shop) => shop.id == affectedId);
-          if (affectedIndex == -1) continue;
-          await _dataService.updateShop(
-            _cacheManager.shops[affectedIndex],
-            isAnonymous: _state.shouldUseAnonymousSession,
-          );
-        }
 
         _state.isSynced = true;
         DebugService().logInfo('共有タブから離脱完了: ショップID=$shopId');
       } catch (e) {
         _state.isSynced = false;
         DebugService().logError('共有タブ削除エラー: $e');
+        // Issue #159: 途中失敗時は全ショップを更新前へ巻き戻す
+        _rollback(originalById, involvedIds);
+        _state.notifyListeners();
         rethrow;
       }
     }
@@ -249,6 +252,10 @@ class SharedTabManager {
     final sharedShops = _cacheManager.shops
         .where((shop) => shop.sharedTabGroupId == sharedTabGroupId)
         .toList();
+
+    // Issue #159: 失敗時に巻き戻すため、関係ショップの更新前状態を退避する
+    final involvedIds = sharedShops.map((shop) => shop.id).toSet();
+    final originalById = _snapshot(involvedIds);
 
     for (final shop in sharedShops) {
       final updatedShop = (newBudget == null || newBudget == 0)
@@ -263,22 +270,61 @@ class SharedTabManager {
     _state.notifyListeners();
 
     if (!_cacheManager.isLocalMode) {
+      final shopsToPersist = _collectShops(involvedIds);
+
       try {
-        for (final shop in sharedShops) {
-          final updatedShop =
-              _cacheManager.shops.firstWhere((s) => s.id == shop.id);
-          await _dataService.updateShop(
-            updatedShop,
-            isAnonymous: _state.shouldUseAnonymousSession,
-          );
-        }
+        await _dataService.updateShopsBatch(
+          shopsToPersist,
+          isAnonymous: _state.shouldUseAnonymousSession,
+        );
 
         _state.isSynced = true;
       } catch (e) {
         _state.isSynced = false;
         DebugService().logError('共有タブ予算同期エラー: $e');
+        // Issue #159: 途中失敗時は全ショップを更新前へ巻き戻す
+        _rollback(originalById, involvedIds);
+        _state.notifyListeners();
         rethrow;
       }
+    }
+  }
+
+  // --- Issue #159: 原子的更新の補助メソッド ---
+
+  /// 指定IDの現在のショップ状態（更新前）を退避する。
+  Map<String, Shop> _snapshot(Iterable<String> ids) {
+    final result = <String, Shop>{};
+    for (final id in ids) {
+      final index = _cacheManager.shops.indexWhere((shop) => shop.id == id);
+      if (index != -1) {
+        result[id] = _cacheManager.shops[index];
+      }
+    }
+    return result;
+  }
+
+  /// 指定IDの現在のショップをキャッシュから集めてリスト化する（バッチ保存用）。
+  List<Shop> _collectShops(Iterable<String> ids) {
+    final result = <Shop>[];
+    for (final id in ids) {
+      final index = _cacheManager.shops.indexWhere((shop) => shop.id == id);
+      if (index != -1) {
+        result.add(_cacheManager.shops[index]);
+      }
+    }
+    return result;
+  }
+
+  /// 退避しておいた状態へキャッシュを巻き戻し、保留中フラグも除去する。
+  void _rollback(Map<String, Shop> originalById, Iterable<String> involvedIds) {
+    for (final id in involvedIds) {
+      final original = originalById[id];
+      final index = _cacheManager.shops.indexWhere((shop) => shop.id == id);
+      if (index != -1 && original != null) {
+        _cacheManager.shops[index] = original;
+      }
+      _shopRepository.pendingUpdates.remove(id);
     }
   }
 }

--- a/lib/providers/repositories/shop_repository.dart
+++ b/lib/providers/repositories/shop_repository.dart
@@ -197,6 +197,10 @@ class ShopRepository {
     );
 
     // 削除されたタブを他のタブのsharedTabsから削除
+    // Issue #159: 影響を受けたショップIDと更新前状態を記録する
+    // （IDは後のバッチ更新に、更新前状態は失敗時のロールバックに使う）
+    final affectedShopIds = <String>[];
+    final originalAffectedShops = <String, Shop>{};
     for (int i = 0; i < _cacheManager.shops.length; i++) {
       final shop = _cacheManager.shops[i];
       if (shop.sharedTabs.contains(shopId)) {
@@ -211,8 +215,10 @@ class ShopRepository {
           clearSharedTabGroupIcon: updatedSharedTabs.isEmpty,
         );
 
+        originalAffectedShops[shop.id] = shop;
         _cacheManager.shops[i] = updatedShop;
         pendingUpdates[shop.id] = DateTime.now();
+        affectedShopIds.add(updatedShop.id);
       }
     }
 
@@ -232,14 +238,19 @@ class ShopRepository {
           isAnonymous: _state.shouldUseAnonymousSession,
         );
 
-        // 更新された共有タブをFirestoreに保存
-        for (final shop in _cacheManager.shops) {
-          if (pendingUpdates.containsKey(shop.id)) {
-            await _dataService.updateShop(
-              shop,
-              isAnonymous: _state.shouldUseAnonymousSession,
-            );
-          }
+        // Issue #159: 参照を外した共有相手を WriteBatch でまとめて保存する
+        // （順次 await だと途中失敗で一部だけ更新される不整合が残るため）
+        final affectedShops = affectedShopIds
+            .map(
+                (id) => _cacheManager.shops.indexWhere((shop) => shop.id == id))
+            .where((index) => index != -1)
+            .map((index) => _cacheManager.shops[index])
+            .toList();
+        if (affectedShops.isNotEmpty) {
+          await _dataService.updateShopsBatch(
+            affectedShops,
+            isAnonymous: _state.shouldUseAnonymousSession,
+          );
         }
 
         _state.isSynced = true;
@@ -250,12 +261,17 @@ class ShopRepository {
         // エラーが発生した場合は削除を取り消し
         _cacheManager.addShopToCache(shopToDelete);
 
-        // 更新された共有タブの変更も取り消し
-        for (final shop in _cacheManager.shops) {
-          if (pendingUpdates.containsKey(shop.id)) {
-            pendingUpdates.remove(shop.id);
+        // Issue #159: 参照を外した共有相手も更新前の状態へ巻き戻す
+        for (final entry in originalAffectedShops.entries) {
+          final index =
+              _cacheManager.shops.indexWhere((shop) => shop.id == entry.key);
+          if (index != -1) {
+            _cacheManager.shops[index] = entry.value;
           }
+          pendingUpdates.remove(entry.key);
         }
+        // 削除対象自身の保留フラグも除去する
+        pendingUpdates.remove(shopId);
 
         // デフォルトショップの削除記録も取り消し
         if (shopId == '0') {

--- a/lib/services/data/shop_data_operations.dart
+++ b/lib/services/data/shop_data_operations.dart
@@ -60,6 +60,68 @@ mixin ShopDataOperations on DataServiceBase {
     await collection.doc(shop.id).set(updateData, SetOptions(merge: true));
   }
 
+  /// 複数ショップを WriteBatch で一括更新する（Issue #159）。
+  ///
+  /// 共有タブのグループ化・解除のように複数ドキュメントをまとめて更新する場合、
+  /// 順次 `await updateShop()` だと途中失敗で「一部だけ書き込まれた」中途半端な
+  /// 状態が残る。WriteBatch なら **全件成功 or 全件失敗** が Firestore 側で保証される。
+  ///
+  /// 既存 [updateShop] と同じく null 値は [FieldValue.delete] に変換し、
+  /// `set(merge: true)` で「存在すれば更新、なければ作成」とする。
+  Future<void> updateShopsBatch(
+    List<Shop> shops, {
+    bool isAnonymous = false,
+  }) async {
+    // Firebaseが利用できない場合はスキップ
+    if (!isFirebaseAvailable) return;
+    if (shops.isEmpty) return;
+
+    CollectionReference<Map<String, dynamic>> collection;
+    if (isAnonymous) {
+      collection = await anonymousShopsCollection;
+    } else {
+      collection = userShopsCollection;
+    }
+
+    // WriteBatch の上限は 500 操作。共有タブのグループは小規模だが、
+    // 念のため 500 件ごとに分割してコミットする。
+    const int batchLimit = 500;
+    try {
+      for (var start = 0; start < shops.length; start += batchLimit) {
+        final end = (start + batchLimit < shops.length)
+            ? start + batchLimit
+            : shops.length;
+        final chunk = shops.sublist(start, end);
+
+        final batch = firestore.batch();
+        for (final shop in chunk) {
+          // null値を明示的に削除するためにFieldValue.delete()を使用
+          final updateData = <String, dynamic>{};
+          final shopMap = shop.toMap();
+          shopMap.forEach((key, value) {
+            if (value == null) {
+              updateData[key] = FieldValue.delete();
+            } else {
+              updateData[key] = value;
+            }
+          });
+          batch.set(
+            collection.doc(shop.id),
+            updateData,
+            SetOptions(merge: true),
+          );
+        }
+        await batch.commit();
+      }
+    } catch (e) {
+      if (e.toString().contains('permission-denied')) {
+        throw const PermissionDeniedError(
+            'Firebaseの権限エラーです。セキュリティルールを確認してください。');
+      }
+      rethrow;
+    }
+  }
+
   /// ショップを削除（存在しない場合は何もしない）
   Future<void> deleteShop(String shopId, {bool isAnonymous = false}) async {
     // Firebaseが利用できない場合はスキップ

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -3,12 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i3;
+import 'dart:async' as _i5;
 
-import 'package:maikago/models/list.dart' as _i4;
-import 'package:maikago/models/shop.dart' as _i5;
-import 'package:maikago/services/data_service.dart' as _i2;
+import 'package:cloud_firestore/cloud_firestore.dart' as _i2;
+import 'package:firebase_auth/firebase_auth.dart' as _i3;
+import 'package:maikago/models/list.dart' as _i7;
+import 'package:maikago/models/shop.dart' as _i8;
+import 'package:maikago/services/data_service.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i6;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -25,17 +28,180 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: subtype_of_sealed_class
 // ignore_for_file: invalid_use_of_internal_member
 
+class _FakeFirebaseFirestore_0 extends _i1.SmartFake
+    implements _i2.FirebaseFirestore {
+  _FakeFirebaseFirestore_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeFirebaseAuth_1 extends _i1.SmartFake implements _i3.FirebaseAuth {
+  _FakeFirebaseAuth_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeCollectionReference_2<T extends Object?> extends _i1.SmartFake
+    implements _i2.CollectionReference<T> {
+  _FakeCollectionReference_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [DataService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockDataService extends _i1.Mock implements _i2.DataService {
+class MockDataService extends _i1.Mock implements _i4.DataService {
   MockDataService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i3.Future<void> saveItem(
-    _i4.ListItem? item, {
+  _i2.FirebaseFirestore get firestore => (super.noSuchMethod(
+        Invocation.getter(#firestore),
+        returnValue: _FakeFirebaseFirestore_0(
+          this,
+          Invocation.getter(#firestore),
+        ),
+      ) as _i2.FirebaseFirestore);
+
+  @override
+  _i3.FirebaseAuth get auth => (super.noSuchMethod(
+        Invocation.getter(#auth),
+        returnValue: _FakeFirebaseAuth_1(
+          this,
+          Invocation.getter(#auth),
+        ),
+      ) as _i3.FirebaseAuth);
+
+  @override
+  bool get isFirebaseAvailable => (super.noSuchMethod(
+        Invocation.getter(#isFirebaseAvailable),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i2.CollectionReference<Map<String, dynamic>> get userItemsCollection =>
+      (super.noSuchMethod(
+        Invocation.getter(#userItemsCollection),
+        returnValue: _FakeCollectionReference_2<Map<String, dynamic>>(
+          this,
+          Invocation.getter(#userItemsCollection),
+        ),
+      ) as _i2.CollectionReference<Map<String, dynamic>>);
+
+  @override
+  _i2.CollectionReference<Map<String, dynamic>> get userShopsCollection =>
+      (super.noSuchMethod(
+        Invocation.getter(#userShopsCollection),
+        returnValue: _FakeCollectionReference_2<Map<String, dynamic>>(
+          this,
+          Invocation.getter(#userShopsCollection),
+        ),
+      ) as _i2.CollectionReference<Map<String, dynamic>>);
+
+  @override
+  _i5.Future<_i2.CollectionReference<Map<String, dynamic>>>
+      get anonymousItemsCollection => (super.noSuchMethod(
+            Invocation.getter(#anonymousItemsCollection),
+            returnValue:
+                _i5.Future<_i2.CollectionReference<Map<String, dynamic>>>.value(
+                    _FakeCollectionReference_2<Map<String, dynamic>>(
+              this,
+              Invocation.getter(#anonymousItemsCollection),
+            )),
+          ) as _i5.Future<_i2.CollectionReference<Map<String, dynamic>>>);
+
+  @override
+  _i5.Future<_i2.CollectionReference<Map<String, dynamic>>>
+      get anonymousShopsCollection => (super.noSuchMethod(
+            Invocation.getter(#anonymousShopsCollection),
+            returnValue:
+                _i5.Future<_i2.CollectionReference<Map<String, dynamic>>>.value(
+                    _FakeCollectionReference_2<Map<String, dynamic>>(
+              this,
+              Invocation.getter(#anonymousShopsCollection),
+            )),
+          ) as _i5.Future<_i2.CollectionReference<Map<String, dynamic>>>);
+
+  @override
+  _i5.Future<void> saveUserProfile(Map<String, dynamic>? profile) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveUserProfile,
+          [profile],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<Map<String, dynamic>?> getUserProfile() => (super.noSuchMethod(
+        Invocation.method(
+          #getUserProfile,
+          [],
+        ),
+        returnValue: _i5.Future<Map<String, dynamic>?>.value(),
+      ) as _i5.Future<Map<String, dynamic>?>);
+
+  @override
+  _i5.Future<bool> isDataSynced() => (super.noSuchMethod(
+        Invocation.method(
+          #isDataSynced,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<void> clearAnonymousSession() => (super.noSuchMethod(
+        Invocation.method(
+          #clearAnonymousSession,
+          [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<bool> isFirebaseConnected() => (super.noSuchMethod(
+        Invocation.method(
+          #isFirebaseConnected,
+          [],
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<String> getAnonymousSessionId() => (super.noSuchMethod(
+        Invocation.method(
+          #getAnonymousSessionId,
+          [],
+        ),
+        returnValue: _i5.Future<String>.value(_i6.dummyValue<String>(
+          this,
+          Invocation.method(
+            #getAnonymousSessionId,
+            [],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<void> saveItem(
+    _i7.ListItem? item, {
     bool? isAnonymous = false,
   }) =>
       (super.noSuchMethod(
@@ -44,13 +210,13 @@ class MockDataService extends _i1.Mock implements _i2.DataService {
           [item],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i3.Future<void> updateItem(
-    _i4.ListItem? item, {
+  _i5.Future<void> updateItem(
+    _i7.ListItem? item, {
     bool? isAnonymous = false,
   }) =>
       (super.noSuchMethod(
@@ -59,12 +225,12 @@ class MockDataService extends _i1.Mock implements _i2.DataService {
           [item],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i3.Future<void> deleteItem(
+  _i5.Future<void> deleteItem(
     String? itemId, {
     bool? isAnonymous = false,
   }) =>
@@ -74,35 +240,35 @@ class MockDataService extends _i1.Mock implements _i2.DataService {
           [itemId],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i3.Stream<List<_i4.ListItem>> getItems({bool? isAnonymous = false}) =>
+  _i5.Stream<List<_i7.ListItem>> getItems({bool? isAnonymous = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getItems,
           [],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Stream<List<_i4.ListItem>>.empty(),
-      ) as _i3.Stream<List<_i4.ListItem>>);
+        returnValue: _i5.Stream<List<_i7.ListItem>>.empty(),
+      ) as _i5.Stream<List<_i7.ListItem>>);
 
   @override
-  _i3.Future<List<_i4.ListItem>> getItemsOnce({bool? isAnonymous = false}) =>
+  _i5.Future<List<_i7.ListItem>> getItemsOnce({bool? isAnonymous = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getItemsOnce,
           [],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<List<_i4.ListItem>>.value(<_i4.ListItem>[]),
-      ) as _i3.Future<List<_i4.ListItem>>);
+        returnValue: _i5.Future<List<_i7.ListItem>>.value(<_i7.ListItem>[]),
+      ) as _i5.Future<List<_i7.ListItem>>);
 
   @override
-  _i3.Future<void> saveShop(
-    _i5.Shop? shop, {
+  _i5.Future<void> saveShop(
+    _i8.Shop? shop, {
     bool? isAnonymous = false,
   }) =>
       (super.noSuchMethod(
@@ -111,13 +277,13 @@ class MockDataService extends _i1.Mock implements _i2.DataService {
           [shop],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i3.Future<void> updateShop(
-    _i5.Shop? shop, {
+  _i5.Future<void> updateShop(
+    _i8.Shop? shop, {
     bool? isAnonymous = false,
   }) =>
       (super.noSuchMethod(
@@ -126,12 +292,27 @@ class MockDataService extends _i1.Mock implements _i2.DataService {
           [shop],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i3.Future<void> deleteShop(
+  _i5.Future<void> updateShopsBatch(
+    List<_i8.Shop>? shops, {
+    bool? isAnonymous = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateShopsBatch,
+          [shops],
+          {#isAnonymous: isAnonymous},
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> deleteShop(
     String? shopId, {
     bool? isAnonymous = false,
   }) =>
@@ -141,68 +322,29 @@ class MockDataService extends _i1.Mock implements _i2.DataService {
           [shopId],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 
   @override
-  _i3.Stream<List<_i5.Shop>> getShops({bool? isAnonymous = false}) =>
+  _i5.Stream<List<_i8.Shop>> getShops({bool? isAnonymous = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getShops,
           [],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Stream<List<_i5.Shop>>.empty(),
-      ) as _i3.Stream<List<_i5.Shop>>);
+        returnValue: _i5.Stream<List<_i8.Shop>>.empty(),
+      ) as _i5.Stream<List<_i8.Shop>>);
 
   @override
-  _i3.Future<List<_i5.Shop>> getShopsOnce({bool? isAnonymous = false}) =>
+  _i5.Future<List<_i8.Shop>> getShopsOnce({bool? isAnonymous = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getShopsOnce,
           [],
           {#isAnonymous: isAnonymous},
         ),
-        returnValue: _i3.Future<List<_i5.Shop>>.value(<_i5.Shop>[]),
-      ) as _i3.Future<List<_i5.Shop>>);
-
-  @override
-  _i3.Future<void> saveUserProfile(Map<String, dynamic>? profile) =>
-      (super.noSuchMethod(
-        Invocation.method(
-          #saveUserProfile,
-          [profile],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-
-  @override
-  _i3.Future<Map<String, dynamic>?> getUserProfile() => (super.noSuchMethod(
-        Invocation.method(
-          #getUserProfile,
-          [],
-        ),
-        returnValue: _i3.Future<Map<String, dynamic>?>.value(),
-      ) as _i3.Future<Map<String, dynamic>?>);
-
-  @override
-  _i3.Future<bool> isDataSynced() => (super.noSuchMethod(
-        Invocation.method(
-          #isDataSynced,
-          [],
-        ),
-        returnValue: _i3.Future<bool>.value(false),
-      ) as _i3.Future<bool>);
-
-  @override
-  _i3.Future<void> clearAnonymousSession() => (super.noSuchMethod(
-        Invocation.method(
-          #clearAnonymousSession,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
+        returnValue: _i5.Future<List<_i8.Shop>>.value(<_i8.Shop>[]),
+      ) as _i5.Future<List<_i8.Shop>>);
 }

--- a/test/providers/managers/shared_tab_manager_test.dart
+++ b/test/providers/managers/shared_tab_manager_test.dart
@@ -13,8 +13,11 @@ class FakeDataCacheManager implements DataCacheManager {
   @override
   List<Shop> shops = [];
 
+  // テストで Firestore 永続化経路を通すため切替可能にする（既定はローカル）
+  bool localMode = true;
+
   @override
-  bool get isLocalMode => true;
+  bool get isLocalMode => localMode;
 
   // テスト不要のメソッドは空実装
   @override
@@ -53,9 +56,24 @@ class FakeDataProviderState implements DataProviderState {
 class FakeDataService implements DataService {
   final List<Shop> updatedShops = [];
 
+  // updateShopsBatch の呼び出し履歴（各要素が1回のバッチで渡されたショップ群）
+  final List<List<Shop>> batchCalls = [];
+
+  // true のときバッチ commit を失敗させ、途中失敗を再現する
+  bool failBatch = false;
+
   @override
   Future<void> updateShop(Shop shop, {bool isAnonymous = false}) async {
     updatedShops.add(shop);
+  }
+
+  @override
+  Future<void> updateShopsBatch(List<Shop> shops,
+      {bool isAnonymous = false}) async {
+    batchCalls.add(List<Shop>.of(shops));
+    if (failBatch) {
+      throw Exception('batch commit failed');
+    }
   }
 
   @override
@@ -492,6 +510,201 @@ void main() {
       await manager.syncSharedTabBudget('group_1', 1000);
 
       expect(state.notifyCount, greaterThan(0));
+    });
+  });
+
+  // Issue #159: 共有タブのグループ更新を WriteBatch で原子化し、
+  // 途中失敗時はローカルキャッシュを更新前に巻き戻す
+  group('updateSharedTab - 原子性とロールバック（Issue #159）', () {
+    setUp(() {
+      // クラウドモードにして Firestore 永続化経路を通す
+      cacheManager.localMode = false;
+    });
+
+    test('成功時は順次updateShopではなくバッチ1回でまとめて保存する', () async {
+      cacheManager.shops = [
+        createSampleShop(id: 'a', name: 'A'),
+        createSampleShop(id: 'b', name: 'B'),
+        createSampleShop(id: 'c', name: 'C'),
+      ];
+
+      await manager.updateSharedTab('a', ['b', 'c']);
+
+      // 順次 updateShop は使わない（部分書き込みを防ぐため）
+      expect(dataService.updatedShops, isEmpty);
+      // バッチは1回だけ呼ばれ、3ショップ全てを含む
+      expect(dataService.batchCalls.length, 1);
+      expect(
+        dataService.batchCalls.first.map((s) => s.id).toSet(),
+        {'a', 'b', 'c'},
+      );
+    });
+
+    test('バッチ失敗時に全ショップが更新前の状態へ巻き戻る', () async {
+      cacheManager.shops = [
+        createSampleShop(id: 'a', name: 'A'),
+        createSampleShop(id: 'b', name: 'B'),
+        createSampleShop(id: 'c', name: 'C'),
+      ];
+      dataService.failBatch = true;
+
+      // 失敗は呼び出し側へ伝播する
+      await expectLater(
+        manager.updateSharedTab('a', ['b', 'c']),
+        throwsA(isA<Exception>()),
+      );
+
+      // 3ショップとも共有設定が付かず、更新前（未共有）に戻っている
+      for (final shop in cacheManager.shops) {
+        expect(shop.sharedTabs, isEmpty, reason: '${shop.id} の sharedTabs');
+        expect(shop.sharedTabGroupId, isNull, reason: '${shop.id} の groupId');
+      }
+    });
+
+    test('バッチ失敗時は isSynced=false かつ pendingUpdates がクリアされる', () async {
+      cacheManager.shops = [
+        createSampleShop(id: 'a', name: 'A'),
+        createSampleShop(id: 'b', name: 'B'),
+      ];
+      dataService.failBatch = true;
+
+      await expectLater(
+        manager.updateSharedTab('a', ['b']),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(state.isSynced, false);
+      expect(shopRepository.pendingUpdates.containsKey('a'), false);
+      expect(shopRepository.pendingUpdates.containsKey('b'), false);
+    });
+
+    test('グループ解除の途中失敗でも元の共有状態へ巻き戻る', () async {
+      cacheManager.shops = [
+        createSampleShop(
+          id: 'shop1',
+          sharedTabGroupId: 'group_1',
+          sharedTabs: ['shop2'],
+        ),
+        createSampleShop(
+          id: 'shop2',
+          sharedTabGroupId: 'group_1',
+          sharedTabs: ['shop1'],
+        ),
+      ];
+      dataService.failBatch = true;
+
+      await expectLater(
+        manager.updateSharedTab('shop1', []),
+        throwsA(isA<Exception>()),
+      );
+
+      // 解除前の共有関係が維持されている
+      expect(cacheManager.shops[0].sharedTabGroupId, 'group_1');
+      expect(cacheManager.shops[0].sharedTabs, ['shop2']);
+      expect(cacheManager.shops[1].sharedTabGroupId, 'group_1');
+      expect(cacheManager.shops[1].sharedTabs, ['shop1']);
+    });
+  });
+
+  group('removeFromSharedTab - 原子性とロールバック（Issue #159）', () {
+    setUp(() {
+      cacheManager.localMode = false;
+    });
+
+    test('成功時はバッチ1回で関係ショップをまとめて保存する', () async {
+      cacheManager.shops = [
+        createSampleShop(
+          id: 'a',
+          sharedTabGroupId: 'g',
+          sharedTabs: ['b', 'c'],
+        ),
+        createSampleShop(
+          id: 'b',
+          sharedTabGroupId: 'g',
+          sharedTabs: ['a', 'c'],
+        ),
+        createSampleShop(
+          id: 'c',
+          sharedTabGroupId: 'g',
+          sharedTabs: ['a', 'b'],
+        ),
+      ];
+
+      await manager.removeFromSharedTab('a');
+
+      expect(dataService.updatedShops, isEmpty);
+      expect(dataService.batchCalls.length, 1);
+      expect(
+        dataService.batchCalls.first.map((s) => s.id).toSet(),
+        {'a', 'b', 'c'},
+      );
+    });
+
+    test('バッチ失敗時は離脱前の共有関係へ巻き戻る', () async {
+      cacheManager.shops = [
+        createSampleShop(
+          id: 'a',
+          sharedTabGroupId: 'g',
+          sharedTabs: ['b'],
+        ),
+        createSampleShop(
+          id: 'b',
+          sharedTabGroupId: 'g',
+          sharedTabs: ['a'],
+        ),
+      ];
+      dataService.failBatch = true;
+
+      await expectLater(
+        manager.removeFromSharedTab('a'),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(cacheManager.shops[0].sharedTabs, ['b']);
+      expect(cacheManager.shops[0].sharedTabGroupId, 'g');
+      expect(cacheManager.shops[1].sharedTabs, ['a']);
+      expect(state.isSynced, false);
+    });
+  });
+
+  group('syncSharedTabBudget - 原子性とロールバック（Issue #159）', () {
+    setUp(() {
+      cacheManager.localMode = false;
+    });
+
+    test('成功時はバッチ1回でグループ全メンバーを保存する', () async {
+      cacheManager.shops = [
+        createSampleShop(id: 'shop1', sharedTabGroupId: 'group_1'),
+        createSampleShop(id: 'shop2', sharedTabGroupId: 'group_1'),
+      ];
+
+      await manager.syncSharedTabBudget('group_1', 5000);
+
+      expect(dataService.updatedShops, isEmpty);
+      expect(dataService.batchCalls.length, 1);
+      expect(
+        dataService.batchCalls.first.map((s) => s.id).toSet(),
+        {'shop1', 'shop2'},
+      );
+    });
+
+    test('バッチ失敗時は予算が元の値へ巻き戻る', () async {
+      cacheManager.shops = [
+        createSampleShop(
+            id: 'shop1', sharedTabGroupId: 'group_1', budget: 3000),
+        createSampleShop(
+            id: 'shop2', sharedTabGroupId: 'group_1', budget: 3000),
+      ];
+      dataService.failBatch = true;
+
+      await expectLater(
+        manager.syncSharedTabBudget('group_1', 9000),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(cacheManager.shops[0].budget, 3000);
+      expect(cacheManager.shops[1].budget, 3000);
+      expect(state.isSynced, false);
     });
   });
 }

--- a/test/providers/repositories/shop_repository_test.dart
+++ b/test/providers/repositories/shop_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:maikago/providers/repositories/shop_repository.dart';
 import 'package:maikago/providers/managers/data_cache_manager.dart';
 import 'package:maikago/providers/data_provider_state.dart';
 import 'package:maikago/models/sort_mode.dart';
+import 'package:maikago/models/shop.dart';
 import '../../helpers/test_helpers.dart';
 import '../../mocks.mocks.dart';
 
@@ -413,6 +414,94 @@ void main() {
 
       expect(cacheManager.shops.length, 1);
       expect(cacheManager.shops.first.id, 'shop1');
+    });
+
+    test('削除失敗時は共有相手のsharedTabsも更新前へ巻き戻る（Issue #159）', () async {
+      cacheManager.setLocalMode(false);
+      final target = createSampleShop(
+        id: 'shop1',
+        name: '削除対象',
+        sharedTabs: ['shop2'],
+        sharedTabGroupId: 'group1',
+      );
+      final other = createSampleShop(
+        id: 'shop2',
+        name: '共有相手',
+        sharedTabs: ['shop1'],
+        sharedTabGroupId: 'group1',
+      );
+      cacheManager.addShopToCache(target);
+      cacheManager.addShopToCache(other);
+
+      // ドキュメント削除自体が失敗するケース
+      when(mockDataService.deleteShop(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenThrow(Exception('Firebase error'));
+
+      try {
+        await repository.deleteShop('shop1');
+      } catch (_) {}
+
+      // 削除対象は復活し、共有相手の sharedTabs / groupId も元のまま
+      final restoredOther =
+          cacheManager.shops.firstWhere((s) => s.id == 'shop2');
+      expect(restoredOther.sharedTabs, ['shop1']);
+      expect(restoredOther.sharedTabGroupId, 'group1');
+      expect(repository.pendingUpdates.containsKey('shop2'), false);
+    });
+
+    test('影響を受ける複数の共有相手はバッチ1回でまとめて更新される（Issue #159）', () async {
+      cacheManager.setLocalMode(false);
+      // shop2, shop3 が削除対象 shop1 を共有相手に持つ
+      final target = createSampleShop(
+        id: 'shop1',
+        name: '削除対象',
+        sharedTabs: ['shop2', 'shop3'],
+        sharedTabGroupId: 'group1',
+      );
+      final other1 = createSampleShop(
+        id: 'shop2',
+        name: '共有相手2',
+        sharedTabs: ['shop1', 'shop3'],
+        sharedTabGroupId: 'group1',
+      );
+      final other2 = createSampleShop(
+        id: 'shop3',
+        name: '共有相手3',
+        sharedTabs: ['shop1', 'shop2'],
+        sharedTabGroupId: 'group1',
+      );
+      cacheManager.addShopToCache(target);
+      cacheManager.addShopToCache(other1);
+      cacheManager.addShopToCache(other2);
+
+      when(mockDataService.deleteShop(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenAnswer((_) async {});
+      when(mockDataService.updateShopsBatch(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenAnswer((_) async {});
+
+      await repository.deleteShop('shop1');
+
+      // 順次 updateShop ではなくバッチ1回で更新される
+      verifyNever(mockDataService.updateShop(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      ));
+      final captured = verify(mockDataService.updateShopsBatch(
+        captureAny,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).captured;
+      expect(captured.length, 1);
+      final batchedShops = (captured.first as List).cast<Shop>();
+      expect(
+        batchedShops.map((s) => s.id).toSet(),
+        {'shop2', 'shop3'},
+      );
     });
   });
 


### PR DESCRIPTION
## 対応 Issue
Closes #159

## 背景・問題
共有タブのグループ化・解除（`SharedTabManager.updateSharedTab`）が複数ショップを `await _dataService.updateShop(...)` で**1件ずつ順次**更新しており、途中で通信が失敗すると「一部のショップだけ共有グループに入った/抜けた」中途半端な状態が残っていた。ロールバックもなく `rethrow` のみで、共有相手の画面とも食い違う。

## 変更内容
- **`shop_data_operations.dart`**: `updateShopsBatch()` を新設。Firestore の `WriteBatch` で複数ショップを1回 `commit()` し **全件成功 or 全件失敗** を保証（既存 `updateShop` と同じ `null→FieldValue.delete()` 変換を踏襲、500件ごとに分割、`permission-denied` をラップ）。
- **`shared_tab_manager.dart`**: `updateSharedTab` / `removeFromSharedTab` / `syncSharedTabBudget` を「更新前スナップショット取得 → バッチ保存 → 失敗時はローカルキャッシュ巻き戻し + `pendingUpdates` 除去 + `isSynced=false`」に変更。共通ヘルパ `_snapshot` / `_collectShops` / `_rollback` を追加。
- **`shop_repository.dart`**: `deleteShop` の共有相手更新ループをバッチ化。あわせて**既存の不完全なロールバック**（影響ショップの `sharedTabs` を元に戻していなかった点）も修正。

## 設計判断
- `deleteShop` の**ドキュメント削除自体はバッチに含めない**。`transmissions` の副作用・削除マーカー処理があるため、共有相手の「更新群」だけを原子化し、失敗時に巻き戻す方針とした（Issue の「検討」に対する線引き）。

## 競合シナリオ（2ユーザー同時編集）
本PRは last-write-wins の競合解決方針自体は変更しない。変更点は「1ユーザーの1操作が複数ドキュメントに分割書き込みされて部分適用される」問題の解消で、`WriteBatch` により他ユーザーのリスナーには中間状態が一切配信されなくなる。

## 完了条件
- [x] グループ化対象の一部の書き込みを失敗させたテストで、全ショップが更新前の状態に戻る
- [x] 共有相手側のリアルタイム同期で中途半端な状態が観測されない（WriteBatch の原子性で保証）
- [x] `flutter analyze`（0 issues）/ `flutter test`（436件全パス）

## テスト
- `shared_tab_manager_test.dart`: 原子性（順次でなくバッチ1回）・途中失敗時のロールバック・`isSynced`/`pendingUpdates` を `updateSharedTab` / `removeFromSharedTab` / `syncSharedTabBudget` の3メソッドで追加。
- `shop_repository_test.dart`: `deleteShop` の複数共有相手バッチ更新・失敗時の `sharedTabs` ロールバックを追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)