### PR TITLE
fix(#158): 書き込み失敗の遷移後通知とバッチ削除の部分失敗ロールバック

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:maikago/router.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:maikago/env.dart';
 import 'package:maikago/firebase_options.dart';
+import 'package:maikago/utils/snackbar_utils.dart';
 
 void main() async {
   unawaited(runZonedGuarded(
@@ -169,6 +170,7 @@ class _MyAppState extends State<MyApp> {
           return MaterialApp.router(
             title: 'まいカゴ',
             theme: themeProvider.themeData,
+            scaffoldMessengerKey: rootScaffoldMessengerKey,
             routerConfig: _router,
             builder: (context, child) {
               // Webプラットフォームの場合、横幅の最大制限を設定

--- a/lib/providers/repositories/item_repository.dart
+++ b/lib/providers/repositories/item_repository.dart
@@ -369,45 +369,70 @@ class ItemRepository {
     if (!_cacheManager.isLocalMode) {
       // リアルタイム同期による中間状態の上書きを防止
       _state.isBatchUpdating = true;
+      // 削除に失敗したIDと、最後に発生した例外を記録する。
+      // Future.wait は最初の失敗で例外を投げるが、残りの削除はFirestore側で
+      // 成功してしまう。全件ロールバックすると「成功して消えた分」までローカルに
+      // 復活し不整合になるため、失敗したIDのみを個別に捕捉して戻す。
+      final failedIds = <String>[];
+      Object? lastError;
       try {
-        // 並列で削除を実行（最大5つずつ）
+        // 並列で削除を実行（最大5つずつ）。各削除の成功/失敗を個別に判定する。
         for (int i = 0; i < itemIds.length; i += _batchSize) {
           final batch = itemIds.skip(i).take(_batchSize).toList();
-          await Future.wait(
-            batch.map(
-              (itemId) => _dataService.deleteItem(
-                itemId,
-                isAnonymous: _state.shouldUseAnonymousSession,
-              ),
-            ),
+          final results = await Future.wait(
+            batch.map((itemId) async {
+              try {
+                await _dataService.deleteItem(
+                  itemId,
+                  isAnonymous: _state.shouldUseAnonymousSession,
+                );
+                return null; // 成功
+              } catch (e) {
+                DebugService().logError('Firebase削除エラー (id=$itemId): $e');
+                lastError = e;
+                return itemId; // 失敗したID
+              }
+            }),
+          );
+          failedIds.addAll(results.whereType<String>());
+        }
+
+        if (failedIds.isEmpty) {
+          _state.isSynced = true;
+        } else {
+          _state.isSynced = false;
+
+          // 失敗したIDのみロールバック（成功分はキャッシュからも削除を確定）
+          final failedItems = itemsToDelete
+              .where((item) => failedIds.contains(item.id))
+              .toList();
+          _cacheManager.items.addAll(failedItems);
+
+          // 各アイテムを自分のshopIdのショップにのみ復元する
+          for (int i = 0; i < _cacheManager.shops.length; i++) {
+            final shop = _cacheManager.shops[i];
+            final restoreTargets =
+                failedItems.where((item) => item.shopId == shop.id);
+            if (restoreTargets.isEmpty) continue;
+
+            final updatedItems = List<ListItem>.from(shop.items);
+            for (final item in restoreTargets) {
+              if (!updatedItems.any(
+                (existingItem) => existingItem.id == item.id,
+              )) {
+                updatedItems.add(item);
+              }
+            }
+            _cacheManager.shops[i] = shop.copyWith(items: updatedItems);
+          }
+
+          _state.notifyListeners();
+
+          throw convertToAppException(
+            lastError ?? Exception('一括削除に失敗しました'),
+            contextMessage: 'アイテムの削除',
           );
         }
-
-        _state.isSynced = true;
-      } catch (e) {
-        _state.isSynced = false;
-        DebugService().logError('Firebase一括削除エラー: $e');
-
-        // エラーが発生した場合は削除を取り消し
-        _cacheManager.items.addAll(itemsToDelete);
-
-        // ショップにも復元
-        for (int i = 0; i < _cacheManager.shops.length; i++) {
-          final shop = _cacheManager.shops[i];
-          final updatedItems = List<ListItem>.from(shop.items);
-          for (final item in itemsToDelete) {
-            if (!updatedItems.any(
-              (existingItem) => existingItem.id == item.id,
-            )) {
-              updatedItems.add(item);
-            }
-          }
-          _cacheManager.shops[i] = shop.copyWith(items: updatedItems);
-        }
-
-        _state.notifyListeners();
-
-        throw convertToAppException(e, contextMessage: 'アイテムの削除');
       } finally {
         _state.isBatchUpdating = false;
         _state.notifyListeners();

--- a/lib/screens/main/utils/item_operations.dart
+++ b/lib/screens/main/utils/item_operations.dart
@@ -68,8 +68,8 @@ class ItemOperations {
             shopIndex, currentShop.copyWith(items: revertedItems));
       }
 
-      if (!context.mounted) return;
-      showErrorSnackBar(context, e);
+      // 画面遷移後でも通知できるようグローバルMessenger経由で表示する
+      showGlobalErrorSnackBar(e);
     }
   }
 
@@ -83,8 +83,8 @@ class ItemOperations {
       await context.read<DataProvider>().deleteItem(item.id);
       if (onSuccess != null) await onSuccess();
     } catch (e) {
-      if (!context.mounted) return;
-      showErrorSnackBar(context, e);
+      // 削除直後に画面遷移してもエラーを通知できるようグローバル表示
+      showGlobalErrorSnackBar(e);
     }
   }
 
@@ -96,8 +96,8 @@ class ItemOperations {
     try {
       await context.read<DataProvider>().updateItem(updatedItem);
     } catch (e) {
-      if (!context.mounted) return;
-      showErrorSnackBar(context, e);
+      // 更新直後に画面遷移してもエラーを通知できるようグローバル表示
+      showGlobalErrorSnackBar(e);
     }
   }
 

--- a/lib/utils/snackbar_utils.dart
+++ b/lib/utils/snackbar_utils.dart
@@ -1,5 +1,33 @@
 import 'package:flutter/material.dart';
 
+/// アプリ全体で共有するルートScaffoldMessengerのキー。
+///
+/// `MaterialApp.router` の `scaffoldMessengerKey` に渡して使う。
+/// 画面遷移で元の `BuildContext` が破棄された後でも、このキー経由なら
+/// 通知を表示できる（保存・削除失敗→即画面遷移のシナリオ対策）。
+final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+    GlobalKey<ScaffoldMessengerState>();
+
+/// `BuildContext` に依存せずエラーをSnackBarで表示する。
+///
+/// `rootScaffoldMessengerKey` 経由で表示するため、画面遷移後でも通知できる。
+/// Messengerがまだ生成されていない場合は安全に無視する。
+void showGlobalErrorSnackBar(dynamic error,
+    {Duration duration = const Duration(seconds: 3)}) {
+  final messenger = rootScaffoldMessengerKey.currentState;
+  if (messenger == null) return;
+
+  final message =
+      error is String ? error : error.toString().replaceAll('Exception: ', '');
+  messenger.showSnackBar(
+    SnackBar(
+      content: Text(message),
+      backgroundColor: Theme.of(messenger.context).colorScheme.error,
+      duration: duration,
+    ),
+  );
+}
+
 /// エラーメッセージをSnackBarで表示する
 ///
 /// [error] が Exception の場合は 'Exception: ' プレフィックスを自動除去する。

--- a/test/providers/repositories/item_repository_test.dart
+++ b/test/providers/repositories/item_repository_test.dart
@@ -740,5 +740,73 @@ void main() {
       // finallyでisBatchUpdatingがfalseに戻る
       expect(state.isBatchUpdating, false);
     });
+
+    test('一括削除の部分失敗時は失敗したIDのみロールバックされる', () async {
+      cacheManager.setLocalMode(false);
+      final items = createSampleItems(3, shopId: '0');
+      for (final item in items) {
+        cacheManager.addItemToCache(item);
+      }
+      final shop = createSampleShop(id: '0', name: 'デフォルト', items: items);
+      cacheManager.addShopToCache(shop);
+
+      // item_1 の削除だけ失敗、item_0 と item_2 は成功させる
+      when(mockDataService.deleteItem(
+        'item_1',
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenThrow(Exception('Firebase error'));
+      when(mockDataService.deleteItem(
+        'item_0',
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenAnswer((_) async {});
+      when(mockDataService.deleteItem(
+        'item_2',
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenAnswer((_) async {});
+
+      final idsToDelete = items.map((item) => item.id).toList();
+
+      try {
+        await repository.deleteItems(idsToDelete);
+      } catch (_) {}
+
+      // 失敗した item_1 のみキャッシュに復活、成功分は削除確定
+      expect(cacheManager.items.map((e) => e.id).toList(), ['item_1']);
+      // ショップ側も item_1 のみ復元され、Firestoreと整合する
+      expect(
+        cacheManager.shops.first.items.map((e) => e.id).toList(),
+        ['item_1'],
+      );
+      // 同期失敗状態になる
+      expect(state.isSynced, false);
+    });
+
+    test('一括削除の復元は正しいshopIdのショップにのみ行われる', () async {
+      cacheManager.setLocalMode(false);
+      final itemA = createSampleItem(id: 'a', name: 'A', shopId: '0');
+      final itemB = createSampleItem(id: 'b', name: 'B', shopId: '1');
+      cacheManager.addItemToCache(itemA);
+      cacheManager.addItemToCache(itemB);
+      cacheManager.addShopToCache(
+          createSampleShop(id: '0', name: 'ショップ0', items: [itemA]));
+      cacheManager.addShopToCache(
+          createSampleShop(id: '1', name: 'ショップ1', items: [itemB]));
+
+      // 両方の削除が失敗
+      when(mockDataService.deleteItem(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenThrow(Exception('Firebase error'));
+
+      try {
+        await repository.deleteItems(['a', 'b']);
+      } catch (_) {}
+
+      // 各アイテムは自分のショップにのみ復元される（他ショップへ混入しない）
+      final shop0 = cacheManager.shops.firstWhere((s) => s.id == '0');
+      final shop1 = cacheManager.shops.firstWhere((s) => s.id == '1');
+      expect(shop0.items.map((e) => e.id).toList(), ['a']);
+      expect(shop1.items.map((e) => e.id).toList(), ['b']);
+    });
   });
 }

--- a/test/utils/snackbar_utils_test.dart
+++ b/test/utils/snackbar_utils_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maikago/utils/snackbar_utils.dart';
+
+void main() {
+  group('showGlobalErrorSnackBar', () {
+    testWidgets('画面遷移後でもエラー通知が表示される', (tester) async {
+      // ルートScaffoldMessengerを登録したアプリを用意する
+      await tester.pumpWidget(
+        MaterialApp(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          const Scaffold(body: Center(child: Text('次の画面'))),
+                    ),
+                  ),
+                  child: const Text('進む'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // 別画面へ遷移する（元のcontextは画面外になる）
+      await tester.tap(find.text('進む'));
+      await tester.pumpAndSettle();
+      expect(find.text('次の画面'), findsOneWidget);
+
+      // 遷移後にグローバル通知を出す（contextを渡さない）
+      showGlobalErrorSnackBar('保存に失敗しました');
+      await tester.pump();
+
+      expect(find.text('保存に失敗しました'), findsOneWidget);
+    });
+
+    testWidgets('Exceptionプレフィックスは除去される', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          home: const Scaffold(body: SizedBox.shrink()),
+        ),
+      );
+
+      showGlobalErrorSnackBar(Exception('ネットワークエラー'));
+      await tester.pump();
+
+      expect(find.text('ネットワークエラー'), findsOneWidget);
+      expect(find.textContaining('Exception:'), findsNothing);
+    });
+
+    testWidgets('Messenger未登録でも例外を投げない', (tester) async {
+      // currentStateがnullの状況でも安全に無視する
+      expect(() => showGlobalErrorSnackBar('テスト'), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
## 対応Issue
Closes #158

## 背景・問題
1. **書き込み失敗が画面遷移後に通知されない**: `item_operations.dart` の `deleteItem`/`updateItem`/`handleCheckToggle` は、エラー通知前に `if (!context.mounted) return;` があり、保存・削除直後に画面遷移すると失敗（ロールバック）が起きてもユーザーに通知されなかった。
2. **一括削除の部分失敗で削除済みアイテムが復活**: `item_repository.dart` の `deleteItems()` は `Future.wait` が最初の失敗で例外を投げる一方、残りの削除はFirestore側で成功する。にもかかわらず全件ロールバックしていたため、Firestoreで消えた分までローカルだけ復活し不整合になっていた。さらに復元時に全ショップへ失敗アイテムを追加しており、別ショップへの混入も起きていた。

## 修正内容
- グローバル `rootScaffoldMessengerKey` と `showGlobalErrorSnackBar()` を `snackbar_utils.dart` に追加し、`MaterialApp.router` に登録。`context.mounted` に依存せず遷移後でも通知できるようにした。
- `item_operations.dart` の3つの操作のエラー通知をグローバル方式へ変更（遷移しない `reorderItems` は従来どおり）。
- `deleteItems()` を各削除ごとの成功/失敗判定に変更。**失敗したIDのみロールバック**し、成功分はキャッシュからも削除を確定。復元は `shopId` が一致するショップにのみ行う。

## 競合シナリオ
- 一括削除中に一部だけFirestore削除が失敗 → 成功分は消えたまま、失敗分のみローカル復活。`isSynced=false` を立て、`showGlobalErrorSnackBar` でユーザーへ通知。Firestoreとローカルキャッシュの状態が一致する。

## テスト
- `item_repository_test.dart`: 「部分失敗時は失敗したIDのみロールバック」「復元は正しいshopIdのショップにのみ」を追加。
- `snackbar_utils_test.dart`（新規）: 画面遷移後でもグローバル通知が表示される／Exceptionプレフィックス除去／Messenger未登録でも安全。

## 検証
- [x] `flutter analyze` エラー0
- [x] `flutter test` 全464件パス（新規テスト含む）
- [x] `flutter build web` 成功

## 完了条件
- [x] 保存失敗→即画面遷移のシナリオでエラーが通知される
- [x] 一括削除の部分失敗テストで、Firestoreとローカルキャッシュの状態が一致する
- [x] `flutter analyze` / `flutter test` がパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)