### PR TITLE
fix(#163): 購入情報のクライアント検証と復元タイムアウト時のCompleter放置を修正

### DIFF
--- a/lib/services/one_time_purchase_service.dart
+++ b/lib/services/one_time_purchase_service.dart
@@ -11,6 +11,8 @@ import 'package:maikago/models/one_time_purchase.dart';
 import 'package:maikago/services/debug_service.dart';
 import 'package:maikago/services/purchase/trial_manager.dart';
 import 'package:maikago/services/purchase/purchase_persistence.dart';
+import 'package:maikago/services/purchase/purchase_validator.dart';
+import 'package:maikago/services/purchase/restore_coordinator.dart';
 
 /// 非消耗型アプリ内課金管理サービス
 class OneTimePurchaseService extends ChangeNotifier {
@@ -32,7 +34,7 @@ class OneTimePurchaseService extends ChangeNotifier {
   };
 
   final Map<String, ProductDetails> _productIdToDetails = {};
-  Completer<bool>? _restoreCompleter;
+  final RestoreCoordinator _restoreCoordinator = RestoreCoordinator();
 
   // 購入済み機能の状態
   final Map<String, bool> _userPremiumStatus = {};
@@ -266,9 +268,23 @@ class OneTimePurchaseService extends ChangeNotifier {
   /// 成功した購入の処理
   Future<void> _handleSuccessfulPurchase(
       PurchaseDetails purchaseDetails) async {
+    // クライアント側の一次検証: 不正・未完了の購入情報ではプレミアムを有効化しない。
+    // （真の改竄対策はサーバー側レシート検証で別途対応する。Issue #163 対応案#1）
+    if (!PurchaseValidator.isValidPremiumPurchase(purchaseDetails)) {
+      DebugService().logWarning(
+          '不正または未完了の購入情報を拒否: ${purchaseDetails.productID} / ${purchaseDetails.status}');
+      return;
+    }
+
     // 購入済み機能を更新
-    if (purchaseDetails.productID == 'maikago_premium_unlock') {
+    if (PurchaseValidator.premiumProductIds
+        .contains(purchaseDetails.productID)) {
       _userPremiumStatus[_currentUserId] = true;
+    }
+
+    // 復元イベントなら待機中の復元処理（restorePurchases）を完了させる
+    if (purchaseDetails.status == PurchaseStatus.restored) {
+      _restoreCoordinator.signalRestored();
     }
 
     // ローカルストレージとFirestoreに保存
@@ -331,17 +347,16 @@ class OneTimePurchaseService extends ChangeNotifier {
         return false;
       }
 
-      _restoreCompleter = Completer<bool>();
-      await _inAppPurchase.restorePurchases();
-
-      // 復元完了を待つ（タイムアウト付き）
-      final result = await _restoreCompleter!.future.timeout(
-        const Duration(seconds: 30),
-        onTimeout: () {
-          DebugService().logError('非消耗型購入復元タイムアウト');
-          return false;
-        },
+      // 復元完了待ち・タイムアウト・再試行のためのリセットは
+      // RestoreCoordinator に委譲（タイムアウト時に Completer を放置せず、
+      // 再試行が正常動作することを保証する。Issue #163）
+      final result = await _restoreCoordinator.wait(
+        () => _inAppPurchase.restorePurchases(),
       );
+
+      if (!result) {
+        DebugService().logError('非消耗型購入復元タイムアウト');
+      }
 
       return result;
     } catch (e) {

--- a/lib/services/purchase/purchase_validator.dart
+++ b/lib/services/purchase/purchase_validator.dart
@@ -1,0 +1,36 @@
+import 'package:in_app_purchase/in_app_purchase.dart';
+
+/// 課金の購入情報（[PurchaseDetails]）がプレミアム有効化に値するかを
+/// 検証する純粋ロジック。
+///
+/// 注意: これは「クライアント側の一次防御」であり、署名（レシート）の
+/// 暗号学的検証ではない。改竄に対する真の防御はサーバー（Cloud Functions
+/// での Google Play / App Store レシート検証）で行う必要がある（Issue #163 の
+/// 対応案#1。本バリデータとは別Issueで対応）。
+class PurchaseValidator {
+  PurchaseValidator._();
+
+  /// プレミアム有効化に対応する商品ID。
+  static const Set<String> premiumProductIds = {
+    'maikago_premium_unlock',
+  };
+
+  /// [details] がプレミアムを有効化してよい正規の購入情報かどうかを返す。
+  ///
+  /// 次のすべてを満たす場合のみ true:
+  /// - status が purchased または restored
+  /// - productID が [premiumProductIds] に含まれる
+  /// - serverVerificationData が空でない（空白のみも不可）
+  static bool isValidPremiumPurchase(PurchaseDetails details) {
+    final isCompleted = details.status == PurchaseStatus.purchased ||
+        details.status == PurchaseStatus.restored;
+    if (!isCompleted) return false;
+
+    if (!premiumProductIds.contains(details.productID)) return false;
+
+    final verification = details.verificationData.serverVerificationData;
+    if (verification.trim().isEmpty) return false;
+
+    return true;
+  }
+}

--- a/lib/services/purchase/restore_coordinator.dart
+++ b/lib/services/purchase/restore_coordinator.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+/// 「購入を復元」処理の Completer ライフサイクルを管理する。
+///
+/// in_app_purchase の `restorePurchases()` は復元結果を purchaseStream 経由で
+/// 非同期に通知するため、呼び出し側は「復元イベントが届く」か「タイムアウト」の
+/// いずれかを待つ必要がある。本クラスはその待機・完了・タイムアウト時の
+/// リセットを一元管理し、タイムアウト後の再試行が正常動作することを保証する
+/// （Issue #163: タイムアウト時に Completer が放置され再試行が不安定になる問題）。
+class RestoreCoordinator {
+  RestoreCoordinator({this.timeout = const Duration(seconds: 30)});
+
+  /// 復元完了を待つ最大時間。
+  final Duration timeout;
+
+  Completer<bool>? _completer;
+
+  /// 現在、復元の完了を待機中かどうか。
+  bool get isWaiting => _completer != null && !_completer!.isCompleted;
+
+  /// 復元を開始し、完了（[signalRestored]）またはタイムアウトまで待つ。
+  ///
+  /// [startRestore] は実際の `restorePurchases()` 呼び出し。
+  /// 戻り値は復元成功なら true、タイムアウトなら false。
+  ///
+  /// タイムアウト・完了・例外のいずれの経路でも、最後に内部状態を必ず
+  /// リセットするため、続けて再呼び出ししても前回の残骸に邪魔されない。
+  Future<bool> wait(Future<void> Function() startRestore) async {
+    final completer = Completer<bool>();
+    _completer = completer;
+    try {
+      await startRestore();
+      return await completer.future.timeout(
+        timeout,
+        onTimeout: () => false,
+      );
+    } finally {
+      _completer = null;
+    }
+  }
+
+  /// 復元イベントを受信したときに呼ぶ。待機中の [wait] を true で完了させる。
+  /// 待機していない場合・既に完了済みの場合は何もしない。
+  void signalRestored() {
+    final completer = _completer;
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(true);
+    }
+  }
+}

--- a/test/services/purchase/purchase_validator_test.dart
+++ b/test/services/purchase/purchase_validator_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:maikago/services/purchase/purchase_validator.dart';
+
+/// テスト用に PurchaseDetails を組み立てるヘルパー
+PurchaseDetails _buildDetails({
+  String productID = 'maikago_premium_unlock',
+  String serverVerificationData = 'valid_purchase_token',
+  PurchaseStatus status = PurchaseStatus.purchased,
+}) {
+  return PurchaseDetails(
+    productID: productID,
+    verificationData: PurchaseVerificationData(
+      localVerificationData: 'local',
+      serverVerificationData: serverVerificationData,
+      source: 'google_play',
+    ),
+    transactionDate: '0',
+    status: status,
+  );
+}
+
+void main() {
+  group('PurchaseValidator.isValidPremiumPurchase', () {
+    test('正規の購入（purchased・正しいID・検証データあり）はtrue', () {
+      final details = _buildDetails();
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), true);
+    });
+
+    test('復元（restored）も正規ならtrue', () {
+      final details = _buildDetails(status: PurchaseStatus.restored);
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), true);
+    });
+
+    test('検証データ（serverVerificationData）が空ならfalse', () {
+      final details = _buildDetails(serverVerificationData: '');
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), false);
+    });
+
+    test('商品IDが想定外ならfalse', () {
+      final details = _buildDetails(productID: 'some_other_product');
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), false);
+    });
+
+    test('statusがpendingならfalse', () {
+      final details = _buildDetails(status: PurchaseStatus.pending);
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), false);
+    });
+
+    test('statusがerrorならfalse', () {
+      final details = _buildDetails(status: PurchaseStatus.error);
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), false);
+    });
+
+    test('statusがcanceledならfalse', () {
+      final details = _buildDetails(status: PurchaseStatus.canceled);
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), false);
+    });
+
+    test('検証データが空白のみ（空白文字）ならfalse', () {
+      final details = _buildDetails(serverVerificationData: '   ');
+
+      expect(PurchaseValidator.isValidPremiumPurchase(details), false);
+    });
+  });
+}

--- a/test/services/purchase/restore_coordinator_test.dart
+++ b/test/services/purchase/restore_coordinator_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maikago/services/purchase/restore_coordinator.dart';
+
+void main() {
+  group('RestoreCoordinator', () {
+    test('signalRestoredが呼ばれるとtrueを返す', () async {
+      final coordinator =
+          RestoreCoordinator(timeout: const Duration(seconds: 5));
+
+      final result = await coordinator.wait(() async {
+        // 復元イベントが非同期に届く想定
+        Future.delayed(
+          const Duration(milliseconds: 10),
+          coordinator.signalRestored,
+        );
+      });
+
+      expect(result, true);
+    });
+
+    test('シグナルが来なければタイムアウトでfalseを返す', () async {
+      final coordinator =
+          RestoreCoordinator(timeout: const Duration(milliseconds: 50));
+
+      final result = await coordinator.wait(() async {});
+
+      expect(result, false);
+    });
+
+    test('タイムアウト後はisWaitingがfalse（Completerが放置されない）', () async {
+      final coordinator =
+          RestoreCoordinator(timeout: const Duration(milliseconds: 50));
+
+      await coordinator.wait(() async {});
+
+      expect(coordinator.isWaiting, false);
+    });
+
+    test('タイムアウト→再試行が正常動作する（完了条件②）', () async {
+      final coordinator =
+          RestoreCoordinator(timeout: const Duration(milliseconds: 50));
+
+      // 1回目: シグナルなし → タイムアウトでfalse
+      final first = await coordinator.wait(() async {});
+      expect(first, false);
+
+      // 2回目: 再試行でシグナルあり → true（前回の残骸に邪魔されない）
+      final second = await coordinator.wait(() async {
+        coordinator.signalRestored();
+      });
+      expect(second, true);
+    });
+
+    test('待機していないときのsignalRestoredは例外を投げない', () {
+      final coordinator = RestoreCoordinator();
+
+      expect(coordinator.signalRestored, returnsNormally);
+    });
+
+    test('startRestoreが例外を投げてもisWaitingはfalseにリセットされる', () async {
+      final coordinator =
+          RestoreCoordinator(timeout: const Duration(milliseconds: 50));
+
+      await expectLater(
+        coordinator.wait(() async => throw Exception('restore failed')),
+        throwsException,
+      );
+      expect(coordinator.isWaiting, false);
+    });
+  });
+}


### PR DESCRIPTION
## 概要
Issue #163 のうち、外部設定なしで完結できる範囲（完了条件3項目）を焦点修正。
サーバー側レシート署名検証（対応案#1）と Firestore ルールのロック（#3）は、Google Play / App Store / Google Cloud の外部設定を要するため**別Issueに切り出し**ます。

## 変更内容
### 1. 購入情報のクライアント側検証（対応案: 不正な購入の拒否）
- `lib/services/purchase/purchase_validator.dart`（新規）
  - `PurchaseValidator.isValidPremiumPurchase()` — `status`（purchased/restored）・`productID`・`serverVerificationData`（空・空白のみ不可）を検証する純粋関数
- `_handleSuccessfulPurchase()` で検証 → **不正・未完了の `PurchaseDetails` ではプレミアムを有効化せず拒否ログのみで早期 return**
- ⚠️ これはクライアント側の**一次防御**であり、暗号学的なレシート検証ではありません（真の改竄対策は別Issueのサーバー検証で対応）

### 2. 復元タイムアウト時の Completer 放置を修正（対応案#2）
- `lib/services/purchase/restore_coordinator.dart`（新規）
  - 復元の Completer ライフサイクルを一元管理。`wait()` は**タイムアウト/完了/例外いずれの経路でも内部状態を必ずリセット**（finally）→ タイムアウト後の再試行が正常動作
- **潜在バグも解消**: 従来 `_restoreCompleter` を完了させる箇所が存在せず、`restorePurchases()` は成功時も常時30秒タイムアウトして `false` を返していた。`restored` イベントで `signalRestored()` を呼び完了させるよう修正

## テスト（TDD: 先に失敗テスト → 実装）
- `test/services/purchase/purchase_validator_test.dart`（新規・8ケース）— 不正な `PurchaseDetails`（空検証データ/誤ProductID/pending・error・canceled）でプレミアムが有効化されないことを確認
- `test/services/purchase/restore_coordinator_test.dart`（新規・6ケース）— タイムアウト→再試行が正常動作、放置されないこと、例外時リセットを確認

## 完了条件
- [x] 不正な `PurchaseDetails` ではプレミアムが有効化されないことをテストで確認
- [x] 復元タイムアウト→再試行が正常動作する
- [x] 既存の `one_time_purchase_service_test.dart` がパス

## 検証
- `flutter analyze`: エラー0
- `flutter test`: 全478テストパス（新規14テスト含む）
- `flutter build web`: 成功

## 競合・後方互換
- 正規の購入は `serverVerificationData`（Android=購入トークン / iOS=レシート）が常に非空のため、本検証で弾かれません
- `completePurchase()`（トランザクション確認）は検証結果に関わらず従来どおり実行（プレミアム付与のみをゲート）

## 残課題（別Issue化を推奨）
- 対応案#1: Cloud Functions での Google Play Developer API / App Store Server API によるレシート署名検証
- 対応案#3: Firestore ルールで `purchases` ドキュメントをロックし、Cloud Functions のみが書き込む構成

🤖 Generated with [Claude Code](https://claude.com/claude-code)