### PR TITLE
fix(#198): ファミリー共有 書き込み側 memberIds ライフサイクル/権限の堅牢化（F-1/F-5/F-2）

### DIFF
--- a/docs/superpowers/specs/2026-06-17-family-memberids-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-17-family-memberids-lifecycle-design.md
@@ -95,6 +95,7 @@ allow update: if auth != null &&
 1. **branch 1 の広い信頼モデル**: 既存メンバーは現状も全フィールド更新可（`ownerId` 書き換え・他メンバー削除も可）。F-1/F-5/F-2 の対象外。将来 add/remove 権限を整理する際に最小権限化を検討。
 2. **add-self の招待未検証**: add-self ルール自体は `familyInvites` の承認を検証しない（familyId を知れば誰でも参加可）。既存の潜在ギャップで本Issue対象外。
 3. **subscription の参加/脱退追従**: メンバー増減時の各メンバー `subscription/current.familyMembers` 同期は将来クライアント実装時に対応。
+4. **add-self の members 内容と本人idの束縛**: `isJoiningSelf` は memberIds に本人を1件追加することは強制するが、`members` 配列に入れる member オブジェクトの id までは検証しない（ルールで配列内 map の id を照合できない＝10人ハードコードの根本原因と同じ制約）。CF が members→memberIds を再計算するため、本人と違う id を members に入れると最終 memberIds がそちらに寄る。ただし攻撃者は自分のアクセス権を増やせず（自分は最終 memberIds から外れる）、通常の self-join 以上の能力は得られないため権限昇格にはならない。データ整合性のフォローアップとして記録。
 
 ## 影響範囲・リスク
 

--- a/docs/superpowers/specs/2026-06-17-family-memberids-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-06-17-family-memberids-lifecycle-design.md
@@ -1,0 +1,102 @@
+# ファミリー共有 書き込み側 memberIds ライフサイクル堅牢化 設計
+
+- Issue: #198（由来 PR #197 / 関連 #162）
+- 日付: 2026-06-17
+- 状態: 設計合意済み
+
+## 背景
+
+#162（PR #197）で `families` の読み取りメンバー判定を `memberIds`（UID文字列の配列）に集約し、11人目以降が共有データを読めるようにした。その際のコードレビューで、ファミリー書き込み側のセキュリティ／整合性に関する潜在指摘が3点（F-1/F-5/F-2）見つかった。
+
+いずれも現状クライアントに `families` 書き込みコードが無い（機能休眠中）ため踏めない潜在バグだが、将来クライアントを復活させる際に必ず必要。本Issueは **rules + Cloud Functions + emulator テスト**でこの堅牢化を先に入れる（クライアント書き込みコードは本Issueでは実装しない）。
+
+## 方針の核
+
+> **memberIds をアクセス権の唯一のゲートにし、members と必ずサイズ整合させる。整合はルールで即時強制し、CFトリガで内容を権威的に再計算する（2層防御）。**
+
+`memberIds` は `members`（`{id, name}` の配列）から派生する非正規化フィールド。コピーである以上「元が変わったらコピーも必ず追従」させる責任がある。現状は作成時に1回書くだけで更新経路が無いことが F-1 の根本原因。
+
+## データ契約（families/{familyId}）
+
+| フィールド | 型 | 役割 |
+|---|---|---|
+| `ownerId` | string (UID) | オーナー。作成者本人のみ |
+| `members` | array of `{id, name}` | メンバー一覧（記述メタdata） |
+| `memberIds` | array of UID string | アクセス権の正本（読み書きゲート）。`members` のidと一致 |
+
+- **作成時の契約**: `members = [{id: ownerId, ...}]`（自分1人のみ）, `memberIds = [ownerId]`
+- **不変条件**: `members` と `memberIds` が両方配列なら `size()` 一致
+
+## 変更対象と各対応
+
+### F-2【create の検証】
+`firestore.rules` の `families` create:
+- 既存: `ownerId == auth.uid` のみ
+- 追加: **members は自分1人のみ**・**memberIds は `[ownerId]` のみ**を強制
+- 効果: 他人のUIDを詰めた family を作れない → CFが他人の `subscription/current` を上書きする経路を封鎖。参加は add-self 経由のみに限定。
+
+### F-5【add-self / self-leave を memberIds 化（10人上限撤廃）】
+- **self-leave / owner-remove は branch 1（既存メンバーの全更新）＋整合不変条件で吸収**する。`isFamilyMember` は memberIds 判定＝人数無制限なので、上限なしで自然に成立。
+- **add-self（非メンバーの参加）のみ専用 branch を memberIds ベースで新設**:
+  - `uid` を `newMemberIds` に1件だけ追加（`newMemberIds.size() == oldMemberIds.size() + 1`）
+  - 既存idは全保持（`newMemberIds.hasAll(oldMemberIds)`）
+  - 追加されるのは本人のみ（`uid in newMemberIds && !(uid in oldMemberIds)`）
+  - 変更キーは `members`/`memberIds`/`updatedAt` に限定
+- 旧 `isMemberInArray`（members[0..9] の10人ハードコード）依存を解消。read と上限をそろえる。
+
+### F-1【members 変更時の memberIds 整合（2層防御）】
+1. **ルール（即時）**: 全 update に共通不変条件を課す。
+   `members` と `memberIds` が両方配列なら `members.size() == memberIds.size()`。
+   旧データ（memberIds 非配列 / members が map 形式）はこの即時チェックをスキップし、CFトリガに委ねる（回帰防止）。
+   → 「membersだけ縮めて memberIds を放置」ができなくなる。
+2. **CFトリガ（権威）**: `functions/` に `onDocumentUpdated('families/{familyId}')` を新設。
+   - `members` から `memberIds` を再計算し、現状と異なる場合のみ書き戻す。
+   - **変化なしなら早期return**（ループ防止）。
+   - 内容のズレ（誤ったid除去など、サイズ整合は満たすが中身が違うケース）も数秒で是正。
+
+## なぜ branch を増やさず減らせるか
+
+現状の update ルールには branch 1「既存メンバーは全更新可」があり、これが既に owner-remove も self-leave も包含している（旧 branch 3/4 は branch 1 より緩いだけの実質デッドコード）。F-1 の真因は「branch 1 が members を変えても memberIds を要求しない」こと。**共通サイズ整合不変条件を1つ足すと branch 1 を含む全経路が塞がる**。残す専用 branch は「非メンバーが入る add-self」だけ＝最小権限。
+
+更新後の update ルール構造（擬似）:
+```
+allow update: if auth != null &&
+  memberIdsConsistent(request.resource.data) && (
+    isFamilyMember(resource.data, uid) ||              // 既存メンバー/オーナー
+    isJoiningSelfViaMemberIds(old, new, uid)          // 非メンバーの参加(add-self)
+  );
+```
+
+## Cloud Functions の構成
+
+- 純粋関数 `computeMemberIds(members)` を副作用のないモジュール `functions/familyMemberIds.js` に切り出す（`members` 配列 → 重複排除した UID 配列）。`index.js` の `applyFamilyPlanToGroup` からも再利用。
+- `onDocumentUpdated('families/{familyId}')` トリガを `index.js` に追加し、`computeMemberIds` で再計算 → 既存 `memberIds` と内容一致なら何もしない、違えば `{ memberIds }` を merge 書き込み。
+- subscription（familyMembers）の参加/脱退時の追従は本Issューの対象外（feature完成＝将来クライアント実装時）。create時の付与は既存の `applyFamilyPlanToGroup` のまま。
+
+## テスト戦略
+
+- **セキュリティ正本 = emulator rules テスト**（`test/firestore_rules/families.rules.test.js` に追加）:
+  - F-2: 他人を含む create は拒否 / 自分1人のみの create は許可
+  - F-5: 11人超の family で12人目の add-self が成功 / index>9 のメンバーの self-leave が成功（10人上限が消えたことの固定）
+  - F-1: members だけ縮めて memberIds 据え置きの update は拒否（サイズ不一致）/ 両方縮めれば許可 / 削除後の対象メンバーは read・update 不可
+  - 他人を memberIds に追加する add-self は拒否
+- **CF純粋関数 = `node --test`**（追加依存なし。Node 20 内蔵テストランナー）:
+  - `functions/test/familyMemberIds.test.js` で `computeMemberIds` の正常系・重複・壊れ要素(null/id欠如)・空配列を固定。
+
+## 完了条件（Issue 準拠）
+
+- [ ] メンバー削除/脱退後、対象メンバーが `memberIds` 経由で read/update できない
+- [ ] 11人目以降の参加(add-self)/脱退が機能する
+- [ ] create で他人を勝手にメンバーに含められない
+- [ ] 上記を検証する emulator テスト＋CF純粋関数テストを追加
+
+## スコープ外（本Issueでは触らない・フォローアップ観察）
+
+1. **branch 1 の広い信頼モデル**: 既存メンバーは現状も全フィールド更新可（`ownerId` 書き換え・他メンバー削除も可）。F-1/F-5/F-2 の対象外。将来 add/remove 権限を整理する際に最小権限化を検討。
+2. **add-self の招待未検証**: add-self ルール自体は `familyInvites` の承認を検証しない（familyId を知れば誰でも参加可）。既存の潜在ギャップで本Issue対象外。
+3. **subscription の参加/脱退追従**: メンバー増減時の各メンバー `subscription/current.familyMembers` 同期は将来クライアント実装時に対応。
+
+## 影響範囲・リスク
+
+- 機能休眠中のため本番ユーザー影響は実質なし。既存 `families` ドキュメント（あれば）への update は、memberIds 非配列 or members が map 形式なら即時チェックをスキップするため回帰しない。
+- 既存の読み取りテスト（#162 由来）は変更しない＝回帰検出に使える。

--- a/firestore.rules
+++ b/firestore.rules
@@ -61,31 +61,42 @@ service cloud.firestore {
 
     // ファミリー共有機能のルール
     match /families/{familyId} {
-      // 新規作成時はownerId必須 + 自分自身がオーナーであること
+      // 新規作成時の検証（Issue #198 F-2）。
+      // 作成契約: 自分1人のみのファミリーを作る。参加は add-self（招待承認）経由でのみ行う。
+      //   - ownerId は自分自身（string）
+      //   - members は自分1人だけ（[{id: ownerId, ...}]）
+      //   - memberIds は [ownerId] だけ
+      // これにより、攻撃者が他人のUIDを members/memberIds に詰めた family を作って
+      // applyFamilyPlanToGroup に他人の subscription/current を上書きさせる経路を封鎖する。
       allow create: if request.auth != null &&
-        request.resource.data.keys().hasAll(['ownerId', 'members']) &&
+        request.resource.data.keys().hasAll(['ownerId', 'members', 'memberIds']) &&
+        request.resource.data.ownerId is string &&
         request.resource.data.ownerId == request.auth.uid &&
-        request.resource.data.ownerId is string;
+        request.resource.data.members is list &&
+        request.resource.data.members.size() == 1 &&
+        request.resource.data.members[0] is map &&
+        request.resource.data.members[0].id == request.auth.uid &&
+        request.resource.data.memberIds is list &&
+        request.resource.data.memberIds.size() == 1 &&
+        request.resource.data.memberIds.hasOnly([request.auth.uid]);
 
       // 読み取り：メンバーまたはオーナーのみ（人数無制限の memberIds 判定に集約）
       allow read: if request.auth != null &&
         isFamilyMember(resource.data, request.auth.uid);
 
-      // 更新：メンバー、オーナー、または新規メンバー追加時
-      allow update: if request.auth != null && (
-        // 既存メンバーまたはオーナー（人数無制限の memberIds 判定に集約）
-        isFamilyMember(resource.data, request.auth.uid) ||
-        // 新しいメンバーが自分自身を追加する場合（招待承認時）
-        // members配列のサイズが1つ増え、新しいメンバーが自分自身である場合
-        (request.resource.data.members.size() == resource.data.members.size() + 1 &&
-         isAddingSelfAsMember(resource.data.members, request.resource.data.members, request.auth.uid)) ||
-        // オーナーによるメンバー削除時（members配列のサイズが減る場合）
-        (resource.data.ownerId == request.auth.uid &&
-         request.resource.data.members.size() < resource.data.members.size()) ||
-        // 自分自身の脱退時（members配列のサイズが1つ減り、自分が削除される場合）
-        (request.resource.data.members.size() == resource.data.members.size() - 1 &&
-         isRemovingSelfAsMember(resource.data.members, request.resource.data.members, request.auth.uid))
-      );
+      // 更新（Issue #198 F-1 / F-5）。
+      // どの経路でも members と memberIds のサイズ整合を強制（memberIdsConsistent）した上で、
+      //   1. 既存メンバー/オーナー → 全更新可（メンバー削除・自分の脱退もこの経路で吸収。
+      //      判定は memberIds ベース＝人数無制限なので 11人目以降の脱退も成立する）
+      //   2. 非メンバーが自分だけを追加して参加（add-self／招待承認）→ memberIds ベースで判定
+      // 旧 owner-remove / self-leave の専用節は branch1 が包含するため統合。
+      // members 変更時に memberIds を据え置く stale 権限は memberIdsConsistent で即時に弾き、
+      // 内容のズレは onDocumentUpdated トリガ（functions）が権威的に再計算して是正する。
+      allow update: if request.auth != null &&
+        memberIdsConsistent(request.resource.data) && (
+          isFamilyMember(resource.data, request.auth.uid) ||
+          isJoiningSelf(resource.data, request.resource.data, request.auth.uid)
+        );
 
       allow delete: if request.auth != null &&
         resource.data.ownerId == request.auth.uid;
@@ -100,11 +111,11 @@ service cloud.firestore {
       // memberIds を持たない旧データは従来どおり 3/4 のフォールバックで判定する（回帰なし）。
       // Map.get(key, default) でフィールド欠如時のエラーを防ぎ、is list / is map で型不一致エラーを防ぐ。
       //
-      // ⚠ memberIds は members から派生する非正規化フィールド。members を変更する書き込みは
-      //   memberIds も同時に更新しないとズレる（削除済みメンバーが memberIds 経由で読み続ける恐れ）。
-      //   現状 members を作成後に変更する経路はクライアント未実装のため未発生。
-      //   将来 add/remove を実装する際は、書き込み側または onDocumentUpdated トリガで
-      //   memberIds の同期を必ず用意すること（書き込み側の堅牢化は Issue #198 で追跡）。
+      // memberIds は members から派生する非正規化フィールド。Issue #198 で書き込み側を堅牢化済み：
+      //   - update では memberIdsConsistent() が members と memberIds のサイズ整合を即時強制し、
+      //     「members だけ変えて memberIds を据え置く」stale 権限を弾く。
+      //   - functions の onDocumentUpdated('families/{familyId}') が members から memberIds を
+      //     権威的に再計算し、内容のズレも是正する（2層防御）。
       function isFamilyMember(data, userId) {
         return data.ownerId == userId ||
           (data.get('memberIds', []) is list && userId in data.get('memberIds', [])) ||
@@ -131,16 +142,27 @@ service cloud.firestore {
         );
       }
 
-      // ヘルパー関数：自分自身をメンバーとして追加しているかチェック
-      function isAddingSelfAsMember(oldMembers, newMembers, userId) {
-        // 新しいメンバーリストに自分が含まれているが、古いリストには含まれていない
-        return isMemberInArray(newMembers, userId) && !isMemberInArray(oldMembers, userId);
+      // ヘルパー関数：members と memberIds のサイズ整合（Issue #198 F-1・即時不変条件）。
+      // 両方とも配列のときだけサイズ一致を要求する。どちらかが配列でない
+      // （旧データ＝memberIds 無し／members が Map 形式）場合はこの即時チェックをスキップし、
+      // onDocumentUpdated トリガの再計算に委ねる（回帰防止）。
+      function memberIdsConsistent(newData) {
+        return !(newData.get('members', 0) is list) ||
+          !(newData.get('memberIds', 0) is list) ||
+          newData.get('members', []).size() == newData.get('memberIds', []).size();
       }
 
-      // ヘルパー関数：自分自身をメンバーから削除しているかチェック
-      function isRemovingSelfAsMember(oldMembers, newMembers, userId) {
-        // 古いメンバーリストに自分が含まれているが、新しいリストには含まれていない
-        return isMemberInArray(oldMembers, userId) && !isMemberInArray(newMembers, userId);
+      // ヘルパー関数：非メンバーが自分だけを memberIds に追加して参加するか（Issue #198 F-5・add-self）。
+      // memberIds ベースで人数無制限に判定する。変更キーは members / memberIds / updatedAt のみ、
+      // 既存メンバーは全保持し、新しく加わるのは本人だけ（他人を巻き込めない）。
+      function isJoiningSelf(oldData, newData, userId) {
+        return newData.diff(oldData).affectedKeys().hasOnly(['members', 'memberIds', 'updatedAt']) &&
+          oldData.get('memberIds', []) is list &&
+          newData.get('memberIds', []) is list &&
+          newData.get('memberIds', []).hasAll(oldData.get('memberIds', [])) &&
+          newData.get('memberIds', []).size() == oldData.get('memberIds', []).size() + 1 &&
+          userId in newData.get('memberIds', []) &&
+          !(userId in oldData.get('memberIds', []));
       }
     }
 

--- a/functions/familyMemberIds.js
+++ b/functions/familyMemberIds.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// ファミリーの非正規化フィールド memberIds（UID文字列の配列）を members から計算する純粋関数群。
+// Firestore ルールの人数無制限メンバー判定（isFamilyMember）と、書き込み側の堅牢化（Issue #198）で使う。
+// 副作用なし＝node --test で単体テスト可能。index.js から require する。
+
+// members 配列（[{id, name}, ...]）から memberIds（UID文字列の配列）を計算する。
+// - 配列でなければ [] を返す（undefined・null・map形式に防御的）
+// - null 要素・id 欠如の要素は除外（壊れた1件で全体を巻き込まない）
+// - 重複排除はしない（valid な members とサイズ整合を保ち、ルールの memberIdsConsistent と一致させる）
+function computeMemberIds(members) {
+  if (!Array.isArray(members)) return [];
+  return members.filter((m) => m && m.id).map((m) => m.id);
+}
+
+// 2つの memberIds 配列が（順序無視で）同一かを判定する。
+// onDocumentUpdated トリガのループ防止に使う（変化が無ければ書き戻さない）。
+function memberIdsEqual(a, b) {
+  const x = Array.isArray(a) ? a : [];
+  const y = Array.isArray(b) ? b : [];
+  if (x.length !== y.length) return false;
+  const sx = [...x].sort();
+  const sy = [...y].sort();
+  return sx.every((v, i) => v === sy[i]);
+}
+
+module.exports = { computeMemberIds, memberIdsEqual };

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,8 @@ const functions = require('firebase-functions');
 const admin = require('firebase-admin');
 const vision = require('@google-cloud/vision');
 const openai = require('openai');
+// ファミリーの非正規化フィールド memberIds の計算（純粋関数・Issue #198）
+const { computeMemberIds, memberIdsEqual } = require('./familyMemberIds');
 
 admin.initializeApp();
 
@@ -273,8 +275,8 @@ exports.applyFamilyPlanToGroup = onDocumentCreated(
     // Issue #162: Firestoreルールの人数無制限メンバー判定（isFamilyMember）のため、
     // UID文字列の配列 memberIds をファミリードキュメントに付与する。
     // これにより11人目以降のメンバーも共有データを読めるようになる。
-    // 壊れた1件（null要素・id欠如）で関数全体が落ちないよう、要素単位で防御する。
-    const memberIds = members.filter((m) => m && m.id).map((m) => m.id);
+    // 壊れた1件（null要素・id欠如）で関数全体が落ちないよう、computeMemberIds が要素単位で防御する。
+    const memberIds = computeMemberIds(members);
     const batch = admin.firestore().batch();
 
     try {
@@ -301,6 +303,37 @@ exports.applyFamilyPlanToGroup = onDocumentCreated(
       return null;
     } catch (e) {
       logger.error('applyFamilyPlanToGroup error:', e);
+      return null;
+    }
+  }
+);
+
+// Issue #198 F-1: members が変わったら memberIds を権威的に再計算して同期する。
+// 非正規化フィールド memberIds が members とズレると、削除されたメンバーが memberIds 経由で
+// read/update を継続できてしまう（stale 権限）。ルールの memberIdsConsistent はサイズ整合を
+// 即時に強制するが、内容のズレ（誤った id 除去など）はこのトリガがサーバー権威で是正する。
+// ループ防止: 再計算結果が現状と同一なら何も書かない（書き戻しが再びこのトリガを起動するため）。
+exports.syncFamilyMemberIds = onDocumentUpdated(
+  'families/{familyId}',
+  async (event) => {
+    const after = event.data?.after?.data();
+    if (!after) return null;
+
+    const recomputed = computeMemberIds(after.members);
+    const current = Array.isArray(after.memberIds) ? after.memberIds : [];
+
+    // 変化なし → 書き戻さない（無限ループ防止）
+    if (memberIdsEqual(current, recomputed)) return null;
+
+    try {
+      await event.data.after.ref.set({ memberIds: recomputed }, { merge: true });
+      logger.info('syncFamilyMemberIds: recomputed memberIds', {
+        familyId: event.params.familyId,
+        size: recomputed.length,
+      });
+      return null;
+    } catch (e) {
+      logger.error('syncFamilyMemberIds error:', e);
       return null;
     }
   }

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": "20"
   },
+  "scripts": {
+    "test": "node --test \"test/**/*.test.js\""
+  },
   "dependencies": {
     "@google-cloud/vision": "^5.3.7",
     "firebase-admin": "^14.0.0",

--- a/functions/test/familyMemberIds.test.js
+++ b/functions/test/familyMemberIds.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Cloud Functions の memberIds 再計算ロジック（純粋関数）の単体テスト。
+// Node 20+ 内蔵テストランナー（node --test）で実行。追加依存なし。
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { computeMemberIds, memberIdsEqual } = require('../familyMemberIds');
+
+test('computeMemberIds: 正常な members から id 配列を返す', () => {
+  assert.deepEqual(
+    computeMemberIds([
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]),
+    ['a', 'b']
+  );
+});
+
+test('computeMemberIds: null要素・id欠如要素を除外する（壊れた1件で全体を巻き込まない）', () => {
+  assert.deepEqual(
+    computeMemberIds([{ id: 'a' }, null, { name: 'noid' }, { id: 'c' }]),
+    ['a', 'c']
+  );
+});
+
+test('computeMemberIds: 空配列は空配列', () => {
+  assert.deepEqual(computeMemberIds([]), []);
+});
+
+test('computeMemberIds: 配列でなければ空配列（undefined/null/map形式に防御的）', () => {
+  assert.deepEqual(computeMemberIds(undefined), []);
+  assert.deepEqual(computeMemberIds(null), []);
+  assert.deepEqual(computeMemberIds({ a: {}, b: {} }), []);
+});
+
+test('memberIdsEqual: 順序が違っても同一集合なら true（ループ防止用）', () => {
+  assert.equal(memberIdsEqual(['a', 'b', 'c'], ['c', 'a', 'b']), true);
+});
+
+test('memberIdsEqual: 要素が違えば false', () => {
+  assert.equal(memberIdsEqual(['a', 'b'], ['a', 'c']), false);
+});
+
+test('memberIdsEqual: 長さが違えば false', () => {
+  assert.equal(memberIdsEqual(['a'], ['a', 'b']), false);
+});
+
+test('memberIdsEqual: 非配列にも防御的', () => {
+  assert.equal(memberIdsEqual(null, []), true);
+  assert.equal(memberIdsEqual(undefined, ['a']), false);
+});

--- a/test/firestore_rules/families.rules.test.js
+++ b/test/firestore_rules/families.rules.test.js
@@ -15,7 +15,7 @@ import {
   assertSucceeds,
   assertFails,
 } from '@firebase/rules-unit-testing';
-import { doc, getDoc, setDoc } from 'firebase/firestore';
+import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // firestore.rules はリポジトリルートにある（このファイルから2階層上）
@@ -40,6 +40,23 @@ async function seedFamily(familyId, data) {
 function readAs(uid, familyId) {
   const db = testEnv.authenticatedContext(uid).firestore();
   return getDoc(doc(db, 'families', familyId));
+}
+
+// 認証済みコンテキストで families ドキュメントを新規作成（create ルール検証用）
+function createAs(uid, familyId, data) {
+  const db = testEnv.authenticatedContext(uid).firestore();
+  return setDoc(doc(db, 'families', familyId), data);
+}
+
+// 認証済みコンテキストで既存 families ドキュメントを部分更新（update ルール検証用）
+function updateAs(uid, familyId, patch) {
+  const db = testEnv.authenticatedContext(uid).firestore();
+  return updateDoc(doc(db, 'families', familyId), patch);
+}
+
+// members 配列から memberIds（UID配列）を作る
+function idsOf(members) {
+  return members.map((m) => m.id);
 }
 
 before(async () => {
@@ -128,5 +145,129 @@ describe('families の読み取り権限', () => {
     // memberIds が無い旧データでは、配列ハードコードの制限により11人目は読めないまま。
     // → 11人目を救うには memberIds を持たせること、という修正方針を固定する。
     await assertFails(readAs('u10', 'f-legacy-11'));
+  });
+});
+
+// ── Issue #198 F-2: create のメンバー検証 ──────────────────────────
+// create 時に「自分以外のメンバーを含められない」ことを強制する。
+// 作成契約: members = [{id: ownerId}], memberIds = [ownerId]
+describe('families の作成権限 (F-2)', () => {
+  it('オーナー自分1人のみの作成は許可', async () => {
+    await assertSucceeds(
+      createAs('owner', 'f-create-ok', {
+        ownerId: 'owner',
+        members: [{ id: 'owner', name: 'me' }],
+        memberIds: ['owner'],
+      })
+    );
+  });
+
+  it('他人を members に含む作成は拒否（CFが他人のsubscriptionを上書きする経路を封鎖）', async () => {
+    await assertFails(
+      createAs('owner', 'f-create-victim-members', {
+        ownerId: 'owner',
+        members: [
+          { id: 'owner', name: 'me' },
+          { id: 'victim', name: 'v' },
+        ],
+        memberIds: ['owner', 'victim'],
+      })
+    );
+  });
+
+  it('他人を memberIds に含む作成は拒否（members は自分だけでも）', async () => {
+    await assertFails(
+      createAs('owner', 'f-create-victim-ids', {
+        ownerId: 'owner',
+        members: [{ id: 'owner', name: 'me' }],
+        memberIds: ['owner', 'victim'],
+      })
+    );
+  });
+
+  it('memberIds 欠如の作成は拒否（契約: [ownerId] 必須）', async () => {
+    await assertFails(
+      createAs('owner', 'f-create-no-ids', {
+        ownerId: 'owner',
+        members: [{ id: 'owner', name: 'me' }],
+      })
+    );
+  });
+
+  it('ownerId が自分でない作成は拒否（既存挙動の固定）', async () => {
+    await assertFails(
+      createAs('attacker', 'f-create-spoof', {
+        ownerId: 'someoneelse',
+        members: [{ id: 'someoneelse', name: 'x' }],
+        memberIds: ['someoneelse'],
+      })
+    );
+  });
+});
+
+// ── Issue #198 F-5: add-self を memberIds 化（10人上限の撤廃）──────────
+describe('families の参加・脱退 (F-5: memberIds化で人数無制限)', () => {
+  it('11人を超える family に12人目が add-self で参加できる', async () => {
+    const members = makeMembers(11); // u0..u10（11人）
+    await seedFamily('f-join', { ownerId: 'u0', members, memberIds: idsOf(members) });
+    const joiner = 'u11'; // 12人目。旧 isMemberInArray(0..9) では参加判定できなかった。
+    const newMembers = [...members, { id: joiner, name: 'newbie' }];
+    await assertSucceeds(
+      updateAs(joiner, 'f-join', { members: newMembers, memberIds: idsOf(newMembers) })
+    );
+  });
+
+  it('add-self で他人も同時に追加しようとすると拒否', async () => {
+    const members = makeMembers(3);
+    await seedFamily('f-join-bad', { ownerId: 'u0', members, memberIds: idsOf(members) });
+    const joiner = 'u9';
+    const newMembers = [...members, { id: joiner, name: 'j' }, { id: 'stranger', name: 's' }];
+    await assertFails(
+      updateAs(joiner, 'f-join-bad', { members: newMembers, memberIds: idsOf(newMembers) })
+    );
+  });
+
+  it('index>9 のメンバーが脱退できる（branch1=memberIds判定で上限なしを固定）', async () => {
+    const members = makeMembers(12); // u0..u11
+    await seedFamily('f-leave', { ownerId: 'u0', members, memberIds: idsOf(members) });
+    const leaver = 'u11'; // 12人目
+    const remaining = members.filter((m) => m.id !== leaver);
+    await assertSucceeds(
+      updateAs(leaver, 'f-leave', { members: remaining, memberIds: idsOf(remaining) })
+    );
+  });
+});
+
+// ── Issue #198 F-1: members 変更時の memberIds 整合強制 ──────────────
+describe('families の memberIds 整合強制 (F-1)', () => {
+  it('members だけ縮めて memberIds を据え置く update は拒否（stale 防止）', async () => {
+    const members = makeMembers(5); // u0..u4
+    await seedFamily('f-stale', { ownerId: 'u0', members, memberIds: idsOf(members) });
+    // オーナー u0 が u4 を members から外すが memberIds は触らない → サイズ不一致
+    const newMembers = members.filter((m) => m.id !== 'u4');
+    await assertFails(updateAs('u0', 'f-stale', { members: newMembers }));
+  });
+
+  it('members と memberIds を揃えて縮めれば許可（正しい削除）', async () => {
+    const members = makeMembers(5);
+    await seedFamily('f-shrink', { ownerId: 'u0', members, memberIds: idsOf(members) });
+    const newMembers = members.filter((m) => m.id !== 'u4');
+    await assertSucceeds(
+      updateAs('u0', 'f-shrink', { members: newMembers, memberIds: idsOf(newMembers) })
+    );
+  });
+
+  it('削除フロー: オーナー削除後、対象は read も update もできない', async () => {
+    const members = makeMembers(5);
+    await seedFamily('f-flow', { ownerId: 'u0', members, memberIds: idsOf(members) });
+    // オーナーが u4 を正しく削除（members/memberIds 両方）
+    const remaining = members.filter((m) => m.id !== 'u4');
+    await assertSucceeds(
+      updateAs('u0', 'f-flow', { members: remaining, memberIds: idsOf(remaining) })
+    );
+    // u4 はもう read できない
+    await assertFails(readAs('u4', 'f-flow'));
+    // u4 はもう update できない
+    await assertFails(updateAs('u4', 'f-flow', { someField: 'x' }));
   });
 });


### PR DESCRIPTION
## 概要

Issue #198（#162/PR #197 レビュー由来）の F-1/F-5/F-2 に対応。ファミリー共有の**書き込み側**で `memberIds`（アクセス権の正本）が `members` とズレることによる潜在的なセキュリティ/整合性問題を堅牢化する。現状クライアントに `families` 書き込みコードは無く（機能休眠中）、本PRは **rules + Cloud Functions + emulator/単体テスト**を整備する（クライアント書き込みコードは将来対応）。

設計詳細: `docs/superpowers/specs/2026-06-17-family-memberids-lifecycle-design.md`

## 方針

**memberIds をアクセス権の唯一のゲートにし、members と必ずサイズ整合させる。整合はルールで即時強制し、CFトリガで内容を権威的に再計算する（2層防御）。**

## 対応内容

### F-2【create のメンバー検証】
- `firestore.rules` の create を「自分1人のみ」（`members=[{id:ownerId}]`・`memberIds=[ownerId]`）に強制。
- 他人のUIDを詰めた family 作成（`applyFamilyPlanToGroup` が他人の `subscription/current` を上書きする経路）を封鎖。参加は add-self 経由に限定。

### F-5【add-self を memberIds 化（10人上限撤廃）】
- 非メンバーの参加(add-self)を memberIds ベースの差分判定に置換。旧 `isMemberInArray`(members[0..9]) 依存を解消。
- 脱退/削除は branch1（`isFamilyMember`=memberIds判定・人数無制限）が包含するため専用節を統合。
- 旧 `isAddingSelfAsMember`/`isRemovingSelfAsMember` を削除。

### F-1【members 変更時の memberIds 整合（2層防御）】
1. **ルール（即時）**: 全 update に `memberIdsConsistent`（members/memberIds のサイズ整合）を前置。「members だけ縮めて memberIds を据え置く」stale 権限を即時に弾く。
2. **CFトリガ（権威）**: `onDocumentUpdated('families/{familyId}')` を新設し members から memberIds を再計算。内容のズレも是正。変化なしなら書き戻さず無限ループを防止。

## テスト

- **Firestore rules emulator**（`test/firestore_rules/`）: F-1/F-5/F-2 の境界を追加し **19件パス**（既存の#162回帰テスト含む）。
- **CF 単体**（`functions/test/`, `node --test`・追加依存なし）: `computeMemberIds`/`memberIdsEqual` の正常・壊れ要素・空・非配列を **8件パス**。

```
# rules（JDK21+ 必須）
cd test/firestore_rules && npm run test:emulator
# functions
cd functions && npm test
```

## 完了条件（Issue #198）

- [x] メンバー削除/脱退後、対象メンバーが memberIds 経由で read/update できない
- [x] 11人目以降の参加(add-self)/脱退が機能する
- [x] create で他人を勝手にメンバーに含められない
- [x] 上記を検証する emulator テスト＋CF単体テストを追加

## スコープ外（フォローアップ・spec に記録）

1. branch1 の広い信頼モデル（メンバーは現状も全フィールド更新可。`ownerId` 書き換え等）
2. add-self の招待(`familyInvites`)未検証（既存ギャップ）
3. subscription の参加/脱退追従（将来クライアント実装時）
4. add-self の `members` 内容と本人idの束縛（権限昇格にはならない／データ整合性の観察）

## 補足

- 機能休眠中のため本番ユーザー影響は実質なし。旧データ（memberIds 非配列/members が map）は即時チェックをスキップし回帰しない。
- emulator ログに出る `evaluation error`（assertFails 時）は CEL の誤差吸収＋emulator が create/update 両方を評価する仕様によるもので、結果は正しく deny。誤許可は発生しない。

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)