### PR TITLE
fix(#160): バウンス抑止を書き込み完了ベースに変更（同時編集の巻き戻り防止）

### DIFF
--- a/docs/superpowers/specs/2026-06-17-160-bounce-protection-design.md
+++ b/docs/superpowers/specs/2026-06-17-160-bounce-protection-design.md
@@ -1,0 +1,64 @@
+# issue #160 設計: 共同編集時のバウンス抑止を「書き込み完了ベース」に変更
+
+## 背景・利用者への影響
+
+同一アカウントを複数端末で開いて編集していると（例: 1つのまいカゴアカウントをスマホ2台で共有）、
+自分が編集した直後に、相手端末の古いスナップショットが遅延配信されて自分の編集が巻き戻る
+ことがあった（「入力したのに消えた」体験）。
+
+> 補足: 別ユーザー同士でリストを共同編集する機能は現状アプリに存在しない
+> （`transmissions`/`syncData` 等のユーザー間共有はデッドコード）。issue 原文の
+> 「2人で同時編集」は実質「同一アカウント・複数端末」を指す。`sharedTabGroupId`
+> による「共有（同期）タブ」は自分のタブを結合して合計を表示する機能で、保存先は
+> `users/{uid}/shops` のみ。
+
+## 原因
+
+`realtime_sync_manager.dart` のバウンス抑止が **編集時刻から固定10秒** の時間ベースだった。
+危険な期間は「編集 → Firestore書き込み完了 → 自分の書き込みがスナップショットで返る（エコー）」
+までで、その長さ = 書き込み遅延 + 配信遅延。書き込み自体に時間がかかると、エコーが返る前に
+10秒が切れ、書き込み前の古いスナップショットが last-write-wins で勝ってしまっていた。
+
+## 修正方針（対応案#1: 書き込み完了ベース）
+
+保護を「時間」ではなく「書き込みの完了状態」で判定する。
+
+- 各 repository に `inFlightUpdates`（書き込み未完了のID集合）を追加。
+  - 編集開始時: `pendingUpdates[id] = now` ＋ `inFlightUpdates.add(id)`。
+  - 書き込み成功時: `pendingUpdates[id] = now`（**完了時刻に押し直し**）＋ `inFlightUpdates.remove(id)`。
+  - 書き込み失敗時: `inFlightUpdates.remove(id)`（恒久ロック防止。保護は時間窓で自然失効）。
+- 保護判定 `PendingUpdatePolicy.isProtected` の純粋ロジック:
+  - `inFlight == true` → 経過時間に関係なく保護（書き込み遅延が長くても巻き戻らない）。
+    ただしハング対策に安全上限 `maxInFlight`（60秒）。
+  - `inFlight == false` → 完了時刻から `deliveryWindow`（10秒）以内のみ保護。
+- items/shops で重複していた「クリーンアップ＋マージ」を `mergePreferringProtectedLocal` に共通化。
+
+対象は単発の `ItemRepository.updateItem` / `ShopRepository.updateShop`。
+バッチ更新・並べ替えは `isBatchUpdating` フラグで同期エンジンがまるごとスキップするため
+（`realtime_sync_manager` のガード）、in-flight 保護は不要。
+
+## 競合解決の仕様（明文化）
+
+last-write-wins は維持しつつ、次の時間的優先を明確化する:
+
+1. **自分の書き込みが完了するまで**: 自分のローカル値が必ず勝つ（古いリモートで上書きしない）。
+2. **書き込み完了後 `deliveryWindow`(10秒) 以内**: 自分のローカル値を優先（自分のエコー or
+   それより新しいリモートを待つ猶予）。
+3. **`deliveryWindow` 経過後**: リモートを採用する。
+4. **安全上限 `maxInFlight`(60秒)**: 書き込みがハングしても、それ以降はリモートを採用する。
+
+### 限界（既知）
+
+- `updatedAt`/バージョンを持たないため、「書き込み完了後の窓(2)の間に来た、相手の正当な
+  新しい編集」と「自分の書き込み前の古いスナップショット」を区別できない。窓の間は自分優先に
+  なるため、相手の新しい編集が画面に出るのは最大で窓ぶん(～10秒)遅れることがある。
+  これは旧実装（編集から10秒自分優先）と同等で、デグレではない。
+- フィールド単位マージは行わない（ドキュメント単位の last-write-wins）。
+
+## テスト
+
+- `test/providers/managers/pending_update_policy_test.dart`:
+  保護判定の純粋ロジック（書き込み遅延=in-flightを時間で再現）＋共通マージ関数。
+- `test/providers/repositories/item_repository_test.dart` /
+  `shop_repository_test.dart`:
+  書き込み中は `inFlightUpdates` に入り、完了/失敗で外れる（恒久ロック防止）ライフサイクル。

--- a/lib/providers/data_provider.dart
+++ b/lib/providers/data_provider.dart
@@ -138,6 +138,7 @@ class DataProvider extends ChangeNotifier {
     _cacheManager.clearData();
     _cacheManager.clearLastSyncTime();
     _itemRepository.pendingUpdates.clear();
+    _itemRepository.inFlightUpdates.clear();
 
     _state.isSynced = false;
     _cacheManager.setLocalMode(false);
@@ -501,6 +502,7 @@ class DataProvider extends ChangeNotifier {
 
     _cacheManager.clearData();
     _itemRepository.pendingUpdates.clear();
+    _itemRepository.inFlightUpdates.clear();
 
     _state.isSynced = false;
     final isLoggedIn = _authProvider?.isLoggedIn ?? false;

--- a/lib/providers/managers/pending_update_policy.dart
+++ b/lib/providers/managers/pending_update_policy.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+
+/// 楽観的更新のバウンス抑止ポリシー（純粋ロジック・テスト容易）。
+///
+/// issue #160: 保護を「時間ベース（編集から固定10秒）」から
+/// 「書き込み完了ベース」に変更する。
+/// - 書き込みがまだ完了していない間（[inFlight]）は、経過時間に関係なく
+///   ローカルを守る。書き込み遅延が長くても自分の編集が巻き戻らない。
+/// - 書き込み完了後は、配信遅延ぶん（[deliveryWindow]）だけローカルを守る。
+/// - 書き込みがハングしても恒久ロックにならないよう、[maxInFlight] で上限を設ける。
+@immutable
+class PendingUpdatePolicy {
+  const PendingUpdatePolicy({
+    this.deliveryWindow = const Duration(seconds: 10),
+    this.maxInFlight = const Duration(seconds: 60),
+  });
+
+  /// 書き込み完了後、配信遅延ぶんローカルを優先し続ける窓。
+  final Duration deliveryWindow;
+
+  /// 書き込みが完了しない（ハングした）場合に保護を諦める上限。
+  final Duration maxInFlight;
+
+  /// このIDのローカル値を保護（リモートで上書きしない）すべきか。
+  ///
+  /// [markedAt] は保護開始時刻。編集時にセットし、書き込み完了時に押し直す。
+  /// [inFlight] は Firestore 書き込みがまだ完了していない場合 true。
+  /// [now] は現在時刻（テストのため注入可能）。
+  bool isProtected({
+    required DateTime? markedAt,
+    required bool inFlight,
+    required DateTime now,
+  }) {
+    if (markedAt == null) return false;
+    final elapsed = now.difference(markedAt);
+    if (inFlight) {
+      // 書き込み完了まで（安全上限付きで）ローカル優先。経過時間では切らない。
+      return elapsed < maxInFlight;
+    }
+    // 完了後は配信遅延ぶんだけ守る。
+    return elapsed < deliveryWindow;
+  }
+}
+
+/// リモートのリストを正としつつ、保護中のIDだけローカル値を残してマージする。
+///
+/// items / shops の双方で同一の処理を行うため共通化（issue #160）。
+/// - [remote] が結果の母集合（リモートに無いIDは結果に含まれない）。
+/// - [isProtected] が true のIDは、ローカルに存在すればローカル値を採用する。
+/// - 保護中でもローカルに存在しないIDはリモート値を採用する。
+List<T> mergePreferringProtectedLocal<T>({
+  required List<T> remote,
+  required List<T> local,
+  required String Function(T) idOf,
+  required bool Function(String id) isProtected,
+}) {
+  final localById = <String, T>{for (final l in local) idOf(l): l};
+  final merged = <T>[];
+  for (final r in remote) {
+    final id = idOf(r);
+    if (isProtected(id)) {
+      merged.add(localById[id] ?? r);
+    } else {
+      merged.add(r);
+    }
+  }
+  return merged;
+}

--- a/lib/providers/managers/realtime_sync_manager.dart
+++ b/lib/providers/managers/realtime_sync_manager.dart
@@ -6,6 +6,7 @@ import 'package:maikago/models/list.dart';
 import 'package:maikago/models/shop.dart';
 import 'package:maikago/providers/data_provider_state.dart';
 import 'package:maikago/providers/managers/data_cache_manager.dart';
+import 'package:maikago/providers/managers/pending_update_policy.dart';
 import 'package:maikago/providers/repositories/item_repository.dart';
 import 'package:maikago/providers/repositories/shop_repository.dart';
 import 'package:maikago/services/debug_service.dart';
@@ -45,6 +46,9 @@ class RealtimeSyncManager {
   static const int _maxRetries = 5;
   Timer? _retryTimer;
 
+  // バウンス抑止ポリシー（書き込み完了ベース・issue #160）
+  static const PendingUpdatePolicy _policy = PendingUpdatePolicy();
+
   /// リアルタイム購読がアクティブかどうか
   bool get isSubscriptionActive => _isSubscriptionActive;
 
@@ -83,28 +87,15 @@ class RealtimeSyncManager {
           // バッチ更新中はリアルタイム同期を完全に無視
           if (_state.isBatchUpdating) return;
 
-          // 古い保留をクリーンアップ
-          final now = DateTime.now();
-          _itemRepository.pendingUpdates.removeWhere(
-            (_, ts) => now.difference(ts) > const Duration(seconds: 10),
+          // 直前にローカルが更新したアイテムは書き込み完了まで（＋配信遅延ぶん）
+          // ローカル版を優先する（issue #160）。
+          final merged = _mergeWithProtection<ListItem>(
+            remote: remoteItems,
+            local: _cacheManager.items,
+            idOf: (i) => i.id,
+            pendingUpdates: _itemRepository.pendingUpdates,
+            inFlightUpdates: _itemRepository.inFlightUpdates,
           );
-
-          // 直前にローカルが更新したアイテムは短時間ローカル版を優先
-          final currentLocal = List<ListItem>.from(_cacheManager.items);
-          final merged = <ListItem>[];
-          for (final remote in remoteItems) {
-            final pendingAt = _itemRepository.pendingUpdates[remote.id];
-            if (pendingAt != null &&
-                now.difference(pendingAt) < const Duration(seconds: 10)) {
-              final local = currentLocal.firstWhere(
-                (i) => i.id == remote.id,
-                orElse: () => remote,
-              );
-              merged.add(local);
-            } else {
-              merged.add(remote);
-            }
-          }
 
           _cacheManager.updateItems(merged);
           _cacheManager.associateItemsWithShops();
@@ -130,28 +121,15 @@ class RealtimeSyncManager {
           // バッチ更新中はリアルタイム同期を完全に無視
           if (_state.isBatchUpdating) return;
 
-          // 古い保留をクリーンアップ
-          final now = DateTime.now();
-          _shopRepository.pendingUpdates.removeWhere(
-            (_, ts) => now.difference(ts) > const Duration(seconds: 10),
+          // 直前にローカルが更新したショップは書き込み完了まで（＋配信遅延ぶん）
+          // ローカル版を優先する（issue #160）。
+          final merged = _mergeWithProtection<Shop>(
+            remote: remoteShops,
+            local: _cacheManager.shops,
+            idOf: (s) => s.id,
+            pendingUpdates: _shopRepository.pendingUpdates,
+            inFlightUpdates: _shopRepository.inFlightUpdates,
           );
-
-          // 直前にローカルが更新したショップは短時間ローカル版を優先
-          final currentLocal = List<Shop>.from(_cacheManager.shops);
-          final merged = <Shop>[];
-          for (final remote in remoteShops) {
-            final pendingAt = _shopRepository.pendingUpdates[remote.id];
-            if (pendingAt != null &&
-                now.difference(pendingAt) < const Duration(seconds: 10)) {
-              final local = currentLocal.firstWhere(
-                (s) => s.id == remote.id,
-                orElse: () => remote,
-              );
-              merged.add(local);
-            } else {
-              merged.add(remote);
-            }
-          }
 
           _cacheManager.updateShops(merged);
           _cacheManager.removeDuplicateShops();
@@ -177,6 +155,41 @@ class RealtimeSyncManager {
       DebugService().logError('リアルタイム同期開始エラー: $e');
       _scheduleRetry();
     }
+  }
+
+  /// リモートスナップショットを、保護中（書き込み中＋配信遅延窓）のローカル値を
+  /// 残しつつマージする。items/shops 共通処理（issue #160）。
+  ///
+  /// 副作用として、保護が切れた保留（pendingUpdates / inFlightUpdates）を
+  /// クリーンアップする。
+  List<T> _mergeWithProtection<T>({
+    required List<T> remote,
+    required List<T> local,
+    required String Function(T) idOf,
+    required Map<String, DateTime> pendingUpdates,
+    required Set<String> inFlightUpdates,
+  }) {
+    final now = DateTime.now();
+    bool isProtected(String id) => _policy.isProtected(
+          markedAt: pendingUpdates[id],
+          inFlight: inFlightUpdates.contains(id),
+          now: now,
+        );
+
+    // 保護が切れた保留をクリーンアップ（pending と in-flight の両方）
+    for (final id in pendingUpdates.keys.toList()) {
+      if (!isProtected(id)) {
+        pendingUpdates.remove(id);
+        inFlightUpdates.remove(id);
+      }
+    }
+
+    return mergePreferringProtectedLocal<T>(
+      remote: remote,
+      local: local,
+      idOf: idOf,
+      isProtected: isProtected,
+    );
   }
 
   /// リアルタイム同期の停止

--- a/lib/providers/repositories/item_repository.dart
+++ b/lib/providers/repositories/item_repository.dart
@@ -29,6 +29,11 @@ class ItemRepository {
   /// 直近で更新を行ったアイテムのIDとタイムスタンプ（楽観更新のバウンス抑止）
   final Map<String, DateTime> pendingUpdates = {};
 
+  /// Firebaseへの書き込みがまだ完了していないアイテムID（issue #160）。
+  /// in-flightの間は経過時間に関係なくローカルを優先し、書き込み遅延が
+  /// 長くても自分の直前の編集が古いスナップショットで巻き戻らないようにする。
+  final Set<String> inFlightUpdates = {};
+
   // --- アイテム追加 ---
 
   Future<void> addItem(ListItem item) async {
@@ -103,8 +108,9 @@ class ItemRepository {
   // --- アイテム更新 ---
 
   Future<void> updateItem(ListItem item) async {
-    // バウンス抑止のため保留中リストに追加
+    // バウンス抑止：保護開始＋書き込み中フラグ（issue #160）
     pendingUpdates[item.id] = DateTime.now();
+    inFlightUpdates.add(item.id);
 
     // 楽観的更新：UIを即座に更新
     _cacheManager.updateItemInCache(item);
@@ -132,13 +138,22 @@ class ItemRepository {
           item,
           isAnonymous: _state.shouldUseAnonymousSession,
         );
+        // issue #160: 書き込み完了。配信遅延の窓を完了時刻から測り直し、
+        // 書き込み中フラグを解除する。
+        pendingUpdates[item.id] = DateTime.now();
+        inFlightUpdates.remove(item.id);
         _state.isSynced = true;
       } catch (e) {
+        // 書き込み失敗：in-flightを解除し恒久ロックを防ぐ（保護は時間窓で自然失効）。
+        inFlightUpdates.remove(item.id);
         _state.isSynced = false;
         DebugService().logError('Firebase更新エラー: $e');
 
         throw convertToAppException(e, contextMessage: 'アイテムの更新');
       }
+    } else {
+      // ローカルモードは書き込みが無いので即完了扱い。
+      inFlightUpdates.remove(item.id);
     }
   }
 

--- a/lib/providers/repositories/shop_repository.dart
+++ b/lib/providers/repositories/shop_repository.dart
@@ -29,6 +29,11 @@ class ShopRepository {
   /// 直近で更新を行ったショップのIDとタイムスタンプ（楽観更新のバウンス抑止）
   final Map<String, DateTime> pendingUpdates = {};
 
+  /// Firebaseへの書き込みがまだ完了していないショップID（issue #160）。
+  /// in-flightの間は経過時間に関係なくローカルを優先し、書き込み遅延が
+  /// 長くても自分の直前の編集が古いスナップショットで巻き戻らないようにする。
+  final Set<String> inFlightUpdates = {};
+
   // --- デフォルトショップ管理 ---
 
   /// デフォルトショップ（id:'0'）を確保
@@ -155,8 +160,9 @@ class ShopRepository {
     if (index != -1) {
       originalShop = _cacheManager.shops[index]; // 元の状態を保存
       _cacheManager.shops[index] = shop;
-      // 楽観的更新の保護
+      // 楽観的更新の保護：保護開始＋書き込み中フラグ（issue #160）
       pendingUpdates[shop.id] = DateTime.now();
+      inFlightUpdates.add(shop.id);
 
       // バッチ更新中でない場合のみUIを更新
       if (!_state.isBatchUpdating) {
@@ -171,8 +177,16 @@ class ShopRepository {
           shop,
           isAnonymous: _state.shouldUseAnonymousSession,
         );
+        // issue #160: 書き込み完了。配信遅延の窓を完了時刻から測り直し、
+        // 書き込み中フラグを解除する。
+        if (index != -1) {
+          pendingUpdates[shop.id] = DateTime.now();
+          inFlightUpdates.remove(shop.id);
+        }
         _state.isSynced = true;
       } catch (e) {
+        // 書き込み失敗：in-flightを解除し恒久ロックを防ぐ（保護は時間窓で自然失効）。
+        inFlightUpdates.remove(shop.id);
         _state.isSynced = false;
         DebugService().logError('Firebase更新エラー: $e');
 
@@ -184,6 +198,9 @@ class ShopRepository {
 
         throw convertToAppException(e, contextMessage: 'ショップの更新');
       }
+    } else if (index != -1) {
+      // ローカルモードは書き込みが無いので即完了扱い。
+      inFlightUpdates.remove(shop.id);
     }
   }
 

--- a/test/providers/managers/pending_update_policy_test.dart
+++ b/test/providers/managers/pending_update_policy_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:maikago/providers/managers/pending_update_policy.dart';
+
+void main() {
+  // 配信窓10秒・書き込み中の安全上限60秒（既定値と同じ）
+  const policy = PendingUpdatePolicy(
+    deliveryWindow: Duration(seconds: 10),
+    maxInFlight: Duration(seconds: 60),
+  );
+  // 固定の基準時刻（DateTime.now()を使わず決定的にする）
+  final t0 = DateTime(2026, 1, 1, 12, 0, 0);
+
+  group('PendingUpdatePolicy.isProtected', () {
+    test('保護記録が無い(markedAt=null)ならリモートを採用する', () {
+      expect(
+        policy.isProtected(markedAt: null, inFlight: false, now: t0),
+        isFalse,
+      );
+    });
+
+    test('書き込み中なら配信窓(10秒)を超えてもローカルを守る（書き込み遅延の核心・issue #160）', () {
+      // 編集から30秒経過＝旧実装では10秒で保護が切れて巻き戻った状況。
+      final now = t0.add(const Duration(seconds: 30));
+      expect(
+        policy.isProtected(markedAt: t0, inFlight: true, now: now),
+        isTrue,
+      );
+    });
+
+    test('書き込み完了後は配信窓(10秒)以内ならローカルを守る', () {
+      final now = t0.add(const Duration(seconds: 5));
+      expect(
+        policy.isProtected(markedAt: t0, inFlight: false, now: now),
+        isTrue,
+      );
+    });
+
+    test('書き込み完了後、配信窓(10秒)を過ぎたらリモートを採用する', () {
+      final now = t0.add(const Duration(seconds: 11));
+      expect(
+        policy.isProtected(markedAt: t0, inFlight: false, now: now),
+        isFalse,
+      );
+    });
+
+    test('書き込みがハングしても安全上限(60秒)を超えたら保護を諦めリモートを採用する', () {
+      final now = t0.add(const Duration(seconds: 61));
+      expect(
+        policy.isProtected(markedAt: t0, inFlight: true, now: now),
+        isFalse,
+      );
+    });
+
+    test('境界値：書き込み完了からちょうど配信窓(10秒)時点は保護しない（未満のみ保護）', () {
+      final now = t0.add(const Duration(seconds: 10));
+      expect(
+        policy.isProtected(markedAt: t0, inFlight: false, now: now),
+        isFalse,
+      );
+    });
+  });
+
+  group('mergePreferringProtectedLocal', () {
+    test('保護中のIDはローカル値を採用し、非保護のIDはリモート値を採用する', () {
+      const remote = [_E('a', 'remote'), _E('b', 'remote')];
+      const local = [_E('a', 'local'), _E('b', 'local')];
+
+      final merged = mergePreferringProtectedLocal<_E>(
+        remote: remote,
+        local: local,
+        idOf: (e) => e.id,
+        isProtected: (id) => id == 'a', // aだけ保護
+      );
+
+      expect(merged, const [_E('a', 'local'), _E('b', 'remote')]);
+    });
+
+    test('保護中でもローカルに存在しないIDはリモート値を採用する', () {
+      const remote = [_E('a', 'remote')];
+      const local = <_E>[];
+
+      final merged = mergePreferringProtectedLocal<_E>(
+        remote: remote,
+        local: local,
+        idOf: (e) => e.id,
+        isProtected: (id) => true,
+      );
+
+      expect(merged, const [_E('a', 'remote')]);
+    });
+
+    test('リモートに無いIDは結果に含まれない（リモートが正のリスト）', () {
+      const remote = [_E('a', 'remote')];
+      const local = [_E('a', 'local'), _E('deleted', 'local')];
+
+      final merged = mergePreferringProtectedLocal<_E>(
+        remote: remote,
+        local: local,
+        idOf: (e) => e.id,
+        isProtected: (id) => true,
+      );
+
+      expect(merged, const [_E('a', 'local')]);
+    });
+  });
+}
+
+/// テスト用の最小要素（id と中身 tag を持つ）。
+class _E {
+  const _E(this.id, this.tag);
+  final String id;
+  final String tag;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _E && other.id == id && other.tag == tag;
+
+  @override
+  int get hashCode => Object.hash(id, tag);
+}

--- a/test/providers/repositories/item_repository_test.dart
+++ b/test/providers/repositories/item_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:maikago/providers/repositories/item_repository.dart';
@@ -276,6 +278,53 @@ void main() {
         () => repository.updateItem(item),
         throwsA(isA<Exception>()),
       );
+    });
+  });
+
+  group('inFlightUpdates（書き込み完了ベースの保護・issue #160）', () {
+    test('Firebase書き込み中はinFlightUpdatesにIDが入り、完了すると外れる', () async {
+      cacheManager.setLocalMode(false);
+      final item = createSampleItem(id: 'item1', name: 'テスト');
+      cacheManager.addItemToCache(item);
+
+      // 書き込みを保留して「書き込み遅延中」を再現する
+      final completer = Completer<void>();
+      when(mockDataService.updateItem(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenAnswer((_) => completer.future);
+
+      // 完了を待たずにupdateItemを開始
+      final future = repository.updateItem(item);
+
+      // 書き込み中：in-flight（経過時間に関係なくローカルが守られる状態）
+      expect(repository.inFlightUpdates, contains('item1'));
+
+      // 書き込み完了
+      completer.complete();
+      await future;
+
+      // 完了後：in-flight解除。以降の保護はpendingUpdatesの時間窓に委ねる
+      expect(repository.inFlightUpdates, isNot(contains('item1')));
+      expect(repository.pendingUpdates, contains('item1'));
+    });
+
+    test('Firebase書き込み失敗時はinFlightUpdatesが解除される（恒久ロック防止）', () async {
+      cacheManager.setLocalMode(false);
+      final item = createSampleItem(id: 'item1', name: 'テスト');
+      cacheManager.addItemToCache(item);
+
+      when(mockDataService.updateItem(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenThrow(Exception('Firebase error'));
+
+      await expectLater(
+        () => repository.updateItem(item),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(repository.inFlightUpdates, isNot(contains('item1')));
     });
   });
 

--- a/test/providers/repositories/shop_repository_test.dart
+++ b/test/providers/repositories/shop_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -285,6 +287,52 @@ void main() {
       } catch (_) {}
 
       expect(cacheManager.shops.first.name, '元の名前');
+    });
+  });
+
+  group('inFlightUpdates（書き込み完了ベースの保護・issue #160）', () {
+    test('Firebase書き込み中はinFlightUpdatesにIDが入り、完了すると外れる', () async {
+      cacheManager.setLocalMode(false);
+      final shop = createSampleShop(id: 'shop1', name: 'テスト');
+      cacheManager.addShopToCache(shop);
+
+      // 書き込みを保留して「書き込み遅延中」を再現する
+      final completer = Completer<void>();
+      when(mockDataService.updateShop(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenAnswer((_) => completer.future);
+
+      // 完了を待たずにupdateShopを開始
+      final future = repository.updateShop(shop);
+
+      // 書き込み中：in-flight（経過時間に関係なくローカルが守られる状態）
+      expect(repository.inFlightUpdates, contains('shop1'));
+
+      // 書き込み完了
+      completer.complete();
+      await future;
+
+      // 完了後：in-flight解除。以降の保護はpendingUpdatesの時間窓に委ねる
+      expect(repository.inFlightUpdates, isNot(contains('shop1')));
+      expect(repository.pendingUpdates, contains('shop1'));
+    });
+
+    test('Firebase書き込み失敗時はinFlightUpdatesが解除される（恒久ロック防止）', () async {
+      cacheManager.setLocalMode(false);
+      final shop = createSampleShop(id: 'shop1', name: '元の名前');
+      cacheManager.addShopToCache(shop);
+
+      when(mockDataService.updateShop(
+        any,
+        isAnonymous: anyNamed('isAnonymous'),
+      )).thenThrow(Exception('Firebase error'));
+
+      try {
+        await repository.updateShop(shop.copyWith(name: '新しい名前'));
+      } catch (_) {}
+
+      expect(repository.inFlightUpdates, isNot(contains('shop1')));
     });
   });
 


### PR DESCRIPTION
Closes #160

## 概要
同一アカウントを複数端末で編集中、自分の直前の編集が相手端末の古いスナップショットで巻き戻る問題を修正する。バウンス抑止を**時間ベース（編集から固定10秒）→ 書き込み完了ベース**に変更した。

## 背景（issueの再定義）
- 別ユーザー同士の共同編集機能は実在しない（`transmissions`/`syncData` はデッドコード）。issueの「2人で同時編集」は実質**同一アカウント・複数端末**を指す。
- 「共有（同期）タブ」(`sharedTabGroupId`) は自分のタブを結合して合計を表示する機能で、保存先は `users/{uid}/shops` のみ。
- 詳細は #160 の再定義コメント参照。

## 原因
危険な期間は「編集 → 書き込み完了 → 自分の書き込みのエコー受信」までで、長さ = 書き込み遅延 + 配信遅延。保護窓が**編集時刻から固定10秒**だったため、書き込み遅延が長いとエコー前に保護が切れ、古いスナップショットが last-write-wins で勝っていた。

## 変更内容
- **`PendingUpdatePolicy`（新規・純粋ロジック）**: `inFlight==true`（書き込み未完了）は経過時間に関係なく保護（安全上限 `maxInFlight`=60秒）。完了後は `deliveryWindow`=10秒のみ保護。
- **`ItemRepository`/`ShopRepository`**: `inFlightUpdates` を追加。`updateItem`/`updateShop` で書き込み中フラグを管理し、**完了時に保護窓を押し直す**。失敗時は解除（恒久ロック防止）。
- **`realtime_sync_manager`**: items/shops で重複していた保護＋マージを `mergePreferringProtectedLocal` に共通化。
- バッチ更新・並べ替えは `isBatchUpdating` で同期エンジンがスキップするため、in-flight保護は単発の `updateItem`/`updateShop` のみに付与。

## 競合解決の挙動（2ユーザー＝複数端末同時編集時・明文化）
last-write-wins は維持しつつ時間的優先を明確化:
1. 自分の書き込み完了まで → 自分のローカル値が勝つ（古いリモートで上書きしない）
2. 完了後 `deliveryWindow`(10秒) 以内 → 自分のローカル値を優先
3. それ以降 → リモートを採用
4. 安全上限 `maxInFlight`(60秒) → 書き込みがハングしても以降はリモート採用

**既知の限界**: `updatedAt`/バージョンが無いため、窓(2)の間に届いた相手の正当な新編集は最大~10秒遅れて反映される（旧実装と同等・デグレなし）。

詳細設計: `docs/superpowers/specs/2026-06-17-160-bounce-protection-design.md`

## テスト
- `pending_update_policy_test.dart`: 保護判定（書き込み遅延=in-flightを時間で再現）＋共通マージ関数（9件）
- `item_repository_test.dart`/`shop_repository_test.dart`: 書き込み中はin-flight、完了/失敗で解除（恒久ロック防止）

## PR前チェック
- [x] `flutter analyze` エラー0
- [x] `flutter test` 全件パス（468件、新規含む）
- [x] 失敗系（書き込み失敗でin-flight解除＝恒久ロック防止）を確認
- [ ] UI変更なし（ロジックのみ）
- [ ] Web影響なし（同期ロジックのみ・`dart:io`不使用）
