### PR TITLE
refactor: 「共有タブ」→「同期タブ」改名（UI文言・クラス名・コメント）

### DIFF
--- a/lib/models/release_history.dart
+++ b/lib/models/release_history.dart
@@ -56,7 +56,7 @@ class ReleaseHistory {
           category: ChangeCategory.improvement,
         ),
         const ChangeItem(
-          description: '共有タブが起動時に重複して表示されるバグを修正しました。',
+          description: '同期タブが起動時に重複して表示されるバグを修正しました。',
           category: ChangeCategory.bugFix,
         ),
         const ChangeItem(
@@ -170,7 +170,7 @@ class ReleaseHistory {
           category: ChangeCategory.bugFix,
         ),
         const ChangeItem(
-          description: '共有タブの合計金額が正しく更新されない問題を修正しました。',
+          description: '同期タブの合計金額が正しく更新されない問題を修正しました。',
           category: ChangeCategory.bugFix,
         ),
         const ChangeItem(
@@ -200,7 +200,7 @@ class ReleaseHistory {
           category: ChangeCategory.improvement,
         ),
         const ChangeItem(
-          description: '共有タブのデザインを見やすくグループ化しました。',
+          description: '同期タブのデザインを見やすくグループ化しました。',
           category: ChangeCategory.improvement,
         ),
         const ChangeItem(
@@ -258,15 +258,15 @@ class ReleaseHistory {
           category: ChangeCategory.improvement,
         ),
         const ChangeItem(
-          description: 'タブを共有する際、アイコンを設定し、共有タブを区別しやすい機能を追加。',
+          description: 'タブを同期する際、アイコンを設定し、同期タブを区別しやすい機能を追加。',
           category: ChangeCategory.newFeature,
         ),
         const ChangeItem(
-          description: '共有タブのマークをテーマにあった色になるように修正。',
+          description: '同期タブのマークをテーマにあった色になるように修正。',
           category: ChangeCategory.improvement,
         ),
         const ChangeItem(
-          description: '共有タブで現在のタブの合計金額と共有グループ全体の合計金額の両方を表示するように改善。',
+          description: '同期タブで現在のタブの合計金額と同期グループ全体の合計金額の両方を表示するように改善。',
           category: ChangeCategory.improvement,
         ),
       ],

--- a/lib/providers/data_provider.dart
+++ b/lib/providers/data_provider.dart
@@ -1,4 +1,4 @@
-// アプリの業務ロジック（一覧/編集/同期/共有合計）を集約し、UI層に通知
+// アプリの業務ロジック（一覧/編集/同期/同期合計）を集約し、UI層に通知
 import 'package:maikago/services/data_service.dart';
 import 'package:maikago/models/list.dart';
 import 'package:maikago/models/shop.dart';
@@ -9,7 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:maikago/providers/data_provider_state.dart';
 import 'package:maikago/providers/managers/data_cache_manager.dart';
 import 'package:maikago/providers/managers/realtime_sync_manager.dart';
-import 'package:maikago/providers/managers/shared_tab_manager.dart';
+import 'package:maikago/providers/managers/sync_tab_manager.dart';
 import 'package:maikago/providers/repositories/item_repository.dart';
 import 'package:maikago/providers/repositories/shop_repository.dart';
 import 'package:maikago/services/debug_service.dart';
@@ -45,7 +45,7 @@ class DataProvider extends ChangeNotifier {
       shopRepository: _shopRepository,
       state: _state,
     );
-    _sharedTabManager = SharedTabManager(
+    _sharedTabManager = SyncTabManager(
       dataService: _dataService,
       cacheManager: _cacheManager,
       shopRepository: _shopRepository,
@@ -59,7 +59,7 @@ class DataProvider extends ChangeNotifier {
   late final ItemRepository _itemRepository;
   late final ShopRepository _shopRepository;
   late final RealtimeSyncManager _syncManager;
-  late final SharedTabManager _sharedTabManager;
+  late final SyncTabManager _sharedTabManager;
 
   AuthProvider? _authProvider;
   VoidCallback? _authListener;
@@ -534,7 +534,7 @@ class DataProvider extends ChangeNotifier {
     super.dispose();
   }
 
-  // --- 合計・予算計算（SharedTabManagerに委譲） ---
+  // --- 合計・予算計算（SyncTabManagerに委譲） ---
 
   int getDisplayTotal(Shop shop) {
     return _sharedTabManager.getDisplayTotal(shop);
@@ -548,7 +548,7 @@ class DataProvider extends ChangeNotifier {
     return _sharedTabManager.getSharedTabBudget(sharedTabGroupId);
   }
 
-  // --- 共有タブ管理（SharedTabManagerに委譲） ---
+  // --- 同期タブ管理（SyncTabManagerに委譲） ---
 
   Future<void> updateSharedTab(String shopId, List<String> selectedTabIds,
       {String? name, String? sharedTabGroupIcon}) async {

--- a/lib/providers/managers/sync_tab_manager.dart
+++ b/lib/providers/managers/sync_tab_manager.dart
@@ -1,4 +1,4 @@
-// 共有タブのCRUD、合計・予算計算
+// 同期タブのCRUD、合計・予算計算
 import 'package:maikago/services/data_service.dart';
 import 'package:maikago/models/shop.dart';
 import 'package:maikago/providers/data_provider_state.dart';
@@ -7,13 +7,13 @@ import 'package:maikago/providers/repositories/shop_repository.dart';
 import 'package:maikago/services/debug_service.dart';
 import 'package:maikago/utils/calculation_utils.dart';
 
-/// 共有タブの管理を担うクラス。
-/// - 共有タブの作成・更新・削除
-/// - 共有タブ間の参照管理
+/// 同期タブの管理を担うクラス。
+/// - 同期タブの作成・更新・削除
+/// - 同期タブ間の参照管理
 /// - 合計・予算の計算
 /// - Firestore保存
-class SharedTabManager {
-  SharedTabManager({
+class SyncTabManager {
+  SyncTabManager({
     required DataService dataService,
     required DataCacheManager cacheManager,
     required ShopRepository shopRepository,
@@ -54,7 +54,7 @@ class SharedTabManager {
     return null;
   }
 
-  // --- 共有タブ管理 ---
+  // --- 同期タブ管理 ---
 
   Future<void> updateSharedTab(String shopId, List<String> selectedTabIds,
       {String? name, String? sharedTabGroupIcon}) async {
@@ -117,7 +117,7 @@ class SharedTabManager {
       }
     }
 
-    // 共有タブの全メンバーID（自身 + 選択タブ）
+    // 同期タブの全メンバーID（自身 + 選択タブ）
     final allGroupMemberIds = {shopId, ...selectedTabIds};
 
     // 選択されたタブのsharedTabsを正確なグループメンバーに置換
@@ -156,10 +156,10 @@ class SharedTabManager {
         );
 
         _state.isSynced = true;
-        DebugService().logInfo('共有タブ更新完了: ショップID=$shopId');
+        DebugService().logInfo('同期タブ更新完了: ショップID=$shopId');
       } catch (e) {
         _state.isSynced = false;
-        DebugService().logError('共有タブ更新エラー: $e');
+        DebugService().logError('同期タブ更新エラー: $e');
         // Issue #159: 途中失敗時は全ショップを更新前へ巻き戻す
         _rollback(originalById, involvedIds);
         _state.notifyListeners();
@@ -235,10 +235,10 @@ class SharedTabManager {
         );
 
         _state.isSynced = true;
-        DebugService().logInfo('共有タブから離脱完了: ショップID=$shopId');
+        DebugService().logInfo('同期タブから離脱完了: ショップID=$shopId');
       } catch (e) {
         _state.isSynced = false;
-        DebugService().logError('共有タブ削除エラー: $e');
+        DebugService().logError('同期タブ削除エラー: $e');
         // Issue #159: 途中失敗時は全ショップを更新前へ巻き戻す
         _rollback(originalById, involvedIds);
         _state.notifyListeners();
@@ -281,7 +281,7 @@ class SharedTabManager {
         _state.isSynced = true;
       } catch (e) {
         _state.isSynced = false;
-        DebugService().logError('共有タブ予算同期エラー: $e');
+        DebugService().logError('同期タブ予算同期エラー: $e');
         // Issue #159: 途中失敗時は全ショップを更新前へ巻き戻す
         _rollback(originalById, involvedIds);
         _state.notifyListeners();

--- a/lib/providers/repositories/shop_repository.dart
+++ b/lib/providers/repositories/shop_repository.dart
@@ -225,7 +225,7 @@ class ShopRepository {
         final updatedSharedTabs =
             shop.sharedTabs.where((id) => id != shopId).toList();
 
-        // 共有相手がいなくなった場合は共有マークも削除
+        // 同期相手がいなくなった場合は同期マークも削除
         final updatedShop = shop.copyWith(
           sharedTabs: updatedSharedTabs,
           clearSharedTabGroupId: updatedSharedTabs.isEmpty,
@@ -255,7 +255,7 @@ class ShopRepository {
           isAnonymous: _state.shouldUseAnonymousSession,
         );
 
-        // Issue #159: 参照を外した共有相手を WriteBatch でまとめて保存する
+        // Issue #159: 参照を外した同期相手を WriteBatch でまとめて保存する
         // （順次 await だと途中失敗で一部だけ更新される不整合が残るため）
         final affectedShops = affectedShopIds
             .map(
@@ -278,7 +278,7 @@ class ShopRepository {
         // エラーが発生した場合は削除を取り消し
         _cacheManager.addShopToCache(shopToDelete);
 
-        // Issue #159: 参照を外した共有相手も更新前の状態へ巻き戻す
+        // Issue #159: 参照を外した同期相手も更新前の状態へ巻き戻す
         for (final entry in originalAffectedShops.entries) {
           final index =
               _cacheManager.shops.indexWhere((shop) => shop.id == entry.key);

--- a/lib/screens/drawer/settings/privacy_policy_screen.dart
+++ b/lib/screens/drawer/settings/privacy_policy_screen.dart
@@ -226,8 +226,7 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
               content: '本アプリでは、サブスクリプションサービスの提供にあたり、以下の情報を収集する場合があります。\n\n'
                   '• サブスクリプション状態（有効期間、プラン種類等）\n'
                   '• 決済情報（プラットフォーム経由で処理され、当社では直接収集しません）\n'
-                  '• 利用状況データ（機能の使用頻度等）\n'
-                  '• 家族共有メンバー情報（ファミリープランの場合）',
+                  '• 利用状況データ（機能の使用頻度等）',
               settingsState: settingsState,
             ),
             const SizedBox(height: 20),

--- a/lib/screens/main/dialogs/tab_edit_dialog.dart
+++ b/lib/screens/main/dialogs/tab_edit_dialog.dart
@@ -59,7 +59,7 @@ class _TabEditDialogState extends State<TabEditDialog> {
     _buildShareOptions();
   }
 
-  /// 共有選択肢を構築（共有タブは1つの単位として表示）
+  /// 同期選択肢を構築（同期タブは1つの単位として表示）
   late List<_ShareOption> _shareOptions;
 
   void _buildShareOptions() {
@@ -70,10 +70,10 @@ class _TabEditDialogState extends State<TabEditDialog> {
     for (final shop in otherShops) {
       if (shop.sharedTabGroupId != null &&
           shop.sharedTabGroupId != currentGroupId) {
-        // 自分のグループ以外の共有タブ → グループ単位で表示
+        // 自分のグループ以外の同期タブ → グループ単位で表示
         externalGroups.putIfAbsent(shop.sharedTabGroupId!, () => []).add(shop);
       } else {
-        // 未共有タブ or 自分のグループのメンバー → 個別表示
+        // 未同期タブ or 自分のグループのメンバー → 個別表示
         individualShops.add(shop);
       }
     }
@@ -174,7 +174,7 @@ class _TabEditDialogState extends State<TabEditDialog> {
               const SizedBox(height: 16),
               if (otherShops.isNotEmpty) ...[
                 Text(
-                  '共有するタブを選択',
+                  '同期するタブを選択',
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
@@ -187,7 +187,7 @@ class _TabEditDialogState extends State<TabEditDialog> {
                     title: Text(option.label),
                     subtitle: option.isGroup
                         ? Text(
-                            '共有タブ',
+                            '同期タブ',
                             style: theme.textTheme.bodySmall?.copyWith(
                               color: theme.colorScheme.onSurface
                                   .withValues(alpha: 0.6),
@@ -212,7 +212,7 @@ class _TabEditDialogState extends State<TabEditDialog> {
                   Padding(
                     padding: const EdgeInsets.only(top: 8),
                     child: Text(
-                      '共有したいタブを選択すると共有が有効になります。',
+                      '同期したいタブを選択すると同期が有効になります。',
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: theme.hintColor,
                       ),
@@ -222,7 +222,7 @@ class _TabEditDialogState extends State<TabEditDialog> {
               if (otherShops.isEmpty) ...[
                 const SizedBox(height: 16),
                 Text(
-                  '共有できる他のタブがありません。',
+                  '同期できる他のタブがありません。',
                   style: theme.textTheme.bodyMedium,
                 ),
               ],
@@ -241,7 +241,7 @@ class _TabEditDialogState extends State<TabEditDialog> {
   }
 }
 
-/// 共有選択肢（個別タブまたはグループ単位）
+/// 同期選択肢（個別タブまたはグループ単位）
 class _ShareOption {
   const _ShareOption({
     required this.label,

--- a/lib/screens/main/utils/item_operations.dart
+++ b/lib/screens/main/utils/item_operations.dart
@@ -34,7 +34,7 @@ class ItemOperations {
         : dataProvider
             .shops[selectedTabIndex.clamp(0, dataProvider.shops.length - 1)];
 
-    // 共有タブの合計を事前更新
+    // 同期タブの合計を事前更新
     if (shop.sharedTabGroupId != null) {
       dataProvider.notifyDataChanged();
     }
@@ -51,7 +51,7 @@ class ItemOperations {
         item.copyWith(isChecked: checked, sortOrder: newSortOrder),
       );
 
-      // 共有タブの合計を更新
+      // 同期タブの合計を更新
       if (shop.sharedTabGroupId != null) {
         dataProvider.notifyDataChanged();
       }

--- a/lib/screens/main/widgets/bottom_summary_details.dart
+++ b/lib/screens/main/widgets/bottom_summary_details.dart
@@ -81,8 +81,8 @@ class BottomSummaryDetails extends StatelessWidget {
       children: [
         Text(
           budget != null
-              ? (isSharedMode ? '共有残り予算' : '残り予算')
-              : (isSharedMode ? '共有予算' : '予算'),
+              ? (isSharedMode ? '同期残り予算' : '残り予算')
+              : (isSharedMode ? '同期予算' : '予算'),
           style: theme.textTheme.bodyMedium?.copyWith(
             color: theme.subtextColor,
             fontWeight: FontWeight.w500,
@@ -124,7 +124,7 @@ class BottomSummaryDetails extends StatelessWidget {
     );
   }
 
-  /// 共有モードの合計表示
+  /// 同期モードの合計表示
   Widget _buildSharedModeTotalDisplay(
       ThemeData theme, ColorScheme colorScheme) {
     return Column(
@@ -153,12 +153,12 @@ class BottomSummaryDetails extends StatelessWidget {
           ],
         ),
         const SizedBox(height: 8),
-        // 2行目: 共有タブ全体の合計
+        // 2行目: 同期タブ全体の合計
         Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
             Text(
-              '共有合計',
+              '同期合計',
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.subtextColor,
                 fontWeight: FontWeight.w500,

--- a/lib/screens/main/widgets/bottom_summary_widget.dart
+++ b/lib/screens/main/widgets/bottom_summary_widget.dart
@@ -115,7 +115,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
       _lastItemsHash = currentItemsHash;
       _refreshData();
     } else if (sharedTabGroupIdChanged || itemsChanged || budgetChanged) {
-      // 同じタブ内でのアイテム変更、共有タブ変更、または予算変更時
+      // 同じタブ内でのアイテム変更、同期タブ変更、または予算変更時
       _lastItemsHash = currentItemsHash;
       _refreshData();
     }
@@ -147,7 +147,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
   // 全てのサマリーデータを一度に取得
   Future<Map<String, dynamic>> _getAllSummaryData() async {
     try {
-      // 共有タブモードの場合
+      // 同期タブモードの場合
       if (widget.shop.sharedTabGroupId != null) {
         final dataProvider = context.read<DataProvider>();
         final sharedTotal =
@@ -188,7 +188,7 @@ class _BottomSummaryWidgetState extends State<BottomSummaryWidget> {
 
   @override
   Widget build(BuildContext context) {
-    // 即座の計算値を使用（共有モード時は現在のタブのみ計算）
+    // 即座の計算値を使用（同期モード時は現在のタブのみ計算）
     final instantTotal = _calculateCurrentShopTotal();
 
     // キャッシュが初期化されていて、現在のショップに対応するキャッシュの場合はキャッシュを使用

--- a/lib/services/data/shop_data_operations.dart
+++ b/lib/services/data/shop_data_operations.dart
@@ -62,7 +62,7 @@ mixin ShopDataOperations on DataServiceBase {
 
   /// 複数ショップを WriteBatch で一括更新する（Issue #159）。
   ///
-  /// 共有タブのグループ化・解除のように複数ドキュメントをまとめて更新する場合、
+  /// 同期タブのグループ化・解除のように複数ドキュメントをまとめて更新する場合、
   /// 順次 `await updateShop()` だと途中失敗で「一部だけ書き込まれた」中途半端な
   /// 状態が残る。WriteBatch なら **全件成功 or 全件失敗** が Firestore 側で保証される。
   ///
@@ -83,7 +83,7 @@ mixin ShopDataOperations on DataServiceBase {
       collection = userShopsCollection;
     }
 
-    // WriteBatch の上限は 500 操作。共有タブのグループは小規模だが、
+    // WriteBatch の上限は 500 操作。同期タブのグループは小規模だが、
     // 念のため 500 件ごとに分割してコミットする。
     const int batchLimit = 500;
     try {

--- a/lib/utils/tab_sorter.dart
+++ b/lib/utils/tab_sorter.dart
@@ -2,17 +2,17 @@ import 'package:maikago/models/shop.dart';
 
 /// タブの並び順を管理するユーティリティクラス
 class TabSorter {
-  /// 共有タブごとにタブを隣接させる並び順を生成
+  /// 同期タブごとにタブを隣接させる並び順を生成
   ///
   /// 並び順のルール:
-  /// 1. 共有タブごとにグループ化
+  /// 1. 同期タブごとにグループ化
   /// 2. 各グループ内では作成日時順（古い順）
-  /// 3. 共有していないタブは最後に配置
+  /// 3. 同期していないタブは最後に配置
   /// 4. 同じグループのタブは隣接して表示
   static List<Shop> sortShopsBySharedTabs(List<Shop> shops) {
     if (shops.isEmpty) return shops;
 
-    // 1. 共有タブごとに分類
+    // 1. 同期タブごとに分類
     final Map<String, List<Shop>> sharedTabGroups = {};
     final List<Shop> unsharedShops = [];
 
@@ -28,7 +28,7 @@ class TabSorter {
       }
     }
 
-    // 2. 各共有タブ内で作成日時順（古い順）にソート
+    // 2. 各同期タブ内で作成日時順（古い順）にソート
     for (final groupShops in sharedTabGroups.values) {
       groupShops.sort((a, b) {
         final aDate = a.createdAt ?? DateTime(1970);
@@ -37,7 +37,7 @@ class TabSorter {
       });
     }
 
-    // 3. 共有タブをグループID順（作成日時順）でソート
+    // 3. 同期タブをグループID順（作成日時順）でソート
     final sortedGroups = sharedTabGroups.entries.toList()
       ..sort((a, b) {
         // 各グループの最初のタブの作成日時で比較
@@ -48,7 +48,7 @@ class TabSorter {
         return aDate.compareTo(bDate);
       });
 
-    // 4. 共有していないタブも作成日時順（古い順）にソート
+    // 4. 同期していないタブも作成日時順（古い順）にソート
     unsharedShops.sort((a, b) {
       final aDate = a.createdAt ?? DateTime(1970);
       final bDate = b.createdAt ?? DateTime(1970);
@@ -58,12 +58,12 @@ class TabSorter {
     // 5. 最終的な並び順を構築
     final List<Shop> sortedShops = [];
 
-    // 共有タブを順番に追加
+    // 同期タブを順番に追加
     for (final group in sortedGroups) {
       sortedShops.addAll(group.value);
     }
 
-    // 共有していないタブを最後に追加
+    // 同期していないタブを最後に追加
     sortedShops.addAll(unsharedShops);
 
     return sortedShops;

--- a/lib/widgets/premium_upgrade_dialog.dart
+++ b/lib/widgets/premium_upgrade_dialog.dart
@@ -4,7 +4,7 @@ import 'package:maikago/widgets/common_dialog.dart';
 
 /// プレミアムアップグレード誘導ダイアログ（汎用）
 ///
-/// OCR、ショップ、レシピ、共有タブなど、
+/// OCR、ショップ、レシピ、同期タブなど、
 /// 各種機能制限に達した際に表示する共通ダイアログ。
 class PremiumUpgradeDialog extends StatelessWidget {
   const PremiumUpgradeDialog({

--- a/test/providers/managers/sync_tab_manager_test.dart
+++ b/test/providers/managers/sync_tab_manager_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:maikago/models/shop.dart';
-import 'package:maikago/providers/managers/shared_tab_manager.dart';
+import 'package:maikago/providers/managers/sync_tab_manager.dart';
 import 'package:maikago/providers/managers/data_cache_manager.dart';
 import 'package:maikago/providers/data_provider_state.dart';
 import 'package:maikago/providers/repositories/shop_repository.dart';
@@ -81,7 +81,7 @@ class FakeDataService implements DataService {
 }
 
 void main() {
-  late SharedTabManager manager;
+  late SyncTabManager manager;
   late FakeDataCacheManager cacheManager;
   late FakeShopRepository shopRepository;
   late FakeDataProviderState state;
@@ -92,7 +92,7 @@ void main() {
     shopRepository = FakeShopRepository();
     state = FakeDataProviderState();
     dataService = FakeDataService();
-    manager = SharedTabManager(
+    manager = SyncTabManager(
       dataService: dataService,
       cacheManager: cacheManager,
       shopRepository: shopRepository,
@@ -513,7 +513,7 @@ void main() {
     });
   });
 
-  // Issue #159: 共有タブのグループ更新を WriteBatch で原子化し、
+  // Issue #159: 同期タブのグループ更新を WriteBatch で原子化し、
   // 途中失敗時はローカルキャッシュを更新前に巻き戻す
   group('updateSharedTab - 原子性とロールバック（Issue #159）', () {
     setUp(() {


### PR DESCRIPTION
## 概要
機能名「共有タブ」を「**同期タブ**」に改名する。この機能は**自分の複数タブを結合して合計金額を同期表示**するもので、ユーザー間共有ではない（その種のコードは #207 で削除済み）。名称が誤解を招くため改名する。

## 改名範囲（確定スコープ）
- **クラス名**: `SharedTabManager` → `SyncTabManager`（ファイル名 `shared_tab_manager.dart` → `sync_tab_manager.dart`、テストも）
- **UI文言**: 「共有タブ」→「同期タブ」、「共有するタブを選択」「共有モード/予算/合計/残り予算」等を「同期…」に統一
- **コメント・ログ**: 「共有タブ」「共有相手/マーク/選択肢/グループ」等を「同期…」に統一

## 据え置き（意図的）
- **Firestoreフィールド名**（`sharedTabGroupId`/`sharedTabs`/`sharedTabGroupIcon`/旧`sharedGroupId`等）と、それを写すDartプロパティ名 → **データ移行を避けるため変更しない**
- **汎用の「共有」**（`data_provider_state` の「共有する状態」、`snackbar_utils` の「共有するキー」）→ 意味が違うため対象外
- メソッド名（`getSharedTabTotal` 等）→ スコープ外（クラス名のみ）

## 同梱
- 家族機能削除（#207）に伴い、プライバシーポリシー（`privacy_policy_screen.dart`）の「家族共有メンバー情報（ファミリープランの場合）」記述を削除。

## 確認
- [x] `flutter analyze` エラー0
- [x] `flutter test` 全件パス（468件）
- [x] 純粋な改名（挙動変更なし）。既存テストが安全網。

## フォローアップ（別途・法務テキスト）
- 利用規約 `public/terms-of-service.html` に家族共有条項が残る（#207で機能削除済み）。法務テキストのため本PRでは触れず、別途要判断。
