### PR TITLE
fix(#169): OCRタイムアウト修正・ダイアログ角丸をDesignConstants経由に統一

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -143,7 +143,7 @@ exports.analyzeImage = onCall(
           imageContext: { languageHints: ['ja', 'en'] }
         }),
         new Promise((_, reject) =>
-          setTimeout(() => reject(new Error('Vision APIタイムアウト')), 10000)
+          setTimeout(() => reject(new Error('Vision APIタイムアウト')), 12000)
         )
       ]);
 

--- a/lib/widgets/camera_guidelines_dialog.dart
+++ b/lib/widgets/camera_guidelines_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:maikago/services/settings_theme.dart';
+import 'package:maikago/utils/design_constants.dart';
 import 'package:maikago/utils/theme_utils.dart';
 
 /// カメラ使用時のガイドラインと注意喚起ダイアログ
@@ -23,7 +24,7 @@ class _CameraGuidelinesDialogState extends State<CameraGuidelinesDialog> {
   Widget build(BuildContext context) {
     return Dialog(
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(DesignConstants.borderRadiusDialog),
       ),
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 400),

--- a/lib/widgets/common_dialog.dart
+++ b/lib/widgets/common_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:maikago/utils/design_constants.dart';
 import 'package:maikago/utils/dialog_utils.dart';
 import 'package:maikago/utils/theme_utils.dart';
 
@@ -52,7 +53,9 @@ class CommonDialog extends StatelessWidget {
       onPressed: onPressed ?? () => context.pop(),
       style: TextButton.styleFrom(
         foregroundColor: theme.colorScheme.onSurface,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        shape: RoundedRectangleBorder(
+            borderRadius:
+                BorderRadius.circular(DesignConstants.borderRadiusDialog)),
       ),
       child: Text(label),
     );
@@ -70,7 +73,9 @@ class CommonDialog extends StatelessWidget {
       style: ElevatedButton.styleFrom(
         backgroundColor: colorScheme.primary,
         foregroundColor: colorScheme.onPrimary,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        shape: RoundedRectangleBorder(
+            borderRadius:
+                BorderRadius.circular(DesignConstants.borderRadiusDialog)),
         elevation: 0,
       ),
       child: Text(label),
@@ -87,7 +92,9 @@ class CommonDialog extends StatelessWidget {
       onPressed: onPressed,
       style: TextButton.styleFrom(
         foregroundColor: Theme.of(context).colorScheme.error,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        shape: RoundedRectangleBorder(
+            borderRadius:
+                BorderRadius.circular(DesignConstants.borderRadiusDialog)),
       ),
       child: Text(label),
     );
@@ -110,7 +117,9 @@ class CommonDialog extends StatelessWidget {
   static Widget loading(BuildContext context) {
     final theme = Theme.of(context);
     return AlertDialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      shape: RoundedRectangleBorder(
+          borderRadius:
+              BorderRadius.circular(DesignConstants.borderRadiusDialog)),
       backgroundColor: theme.cardColor,
       content: const SizedBox(
         height: 100,
@@ -169,7 +178,9 @@ class CommonDialog extends StatelessWidget {
     final colorScheme = theme.colorScheme;
 
     return AlertDialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      shape: RoundedRectangleBorder(
+          borderRadius:
+              BorderRadius.circular(DesignConstants.borderRadiusDialog)),
       backgroundColor: theme.cardColor,
       insetPadding: insetPadding ??
           const EdgeInsets.symmetric(horizontal: 20, vertical: 24),

--- a/lib/widgets/upgrade_promotion_widget.dart
+++ b/lib/widgets/upgrade_promotion_widget.dart
@@ -4,6 +4,7 @@ import 'package:maikago/services/feature_access_control.dart';
 import 'package:maikago/services/one_time_purchase_service.dart';
 import 'package:go_router/go_router.dart';
 import 'package:maikago/services/settings_theme.dart';
+import 'package:maikago/utils/design_constants.dart';
 import 'package:maikago/utils/theme_utils.dart';
 
 /// 買い切り型アプリ内課金のアップグレード促進UIシステム
@@ -186,7 +187,7 @@ class UpgradePromotionWidget extends StatelessWidget {
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
         ),
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: BorderRadius.circular(DesignConstants.borderRadiusDialog),
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## 概要

Issue #169（軽微な不整合の解消）の対応。

## 変更内容

### OCRタイムアウト不一致の修正
- `functions/index.js`: Vision APIサーバータイムアウトを10秒→**12秒**に変更
  - クライアント (`visionApiTimeoutSeconds = 15秒`) > サーバー（12秒）の関係を維持
  - サーバーが先にタイムアウトした後のクライアント待機5秒（体感上の無反応時間）を3秒に短縮

### デザイン定数の参照統一
- `lib/widgets/common_dialog.dart`: `BorderRadius.circular(20)` を全5箇所 `DesignConstants.borderRadiusDialog` 経由に統一
  - `cancelButton`, `primaryButton`, `destructiveButton`, `loading`, `build` の各ダイアログ
- `lib/widgets/camera_guidelines_dialog.dart`: 同様に統一
- `lib/widgets/upgrade_promotion_widget.dart`: 同様に統一

`DesignConstants.borderRadiusDialog = 20.0` は `lib/utils/design_constants.dart` に定義済み。

## テスト

- `flutter analyze`: エラー0
- `flutter test --exclude-tags=integration`: 477件 全件パス

Closes #169