### PR TITLE
feat(#204): iOS App Store Server API購入検証を追加

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,7 @@ const { verifyAndroidPurchase } = require('./purchase/android_verifier');
 const {
   createAndroidPublisherDeps,
 } = require('./purchase/android_publisher_client');
+const { verifyIosPurchase } = require('./purchase/ios_verifier');
 
 admin.initializeApp();
 
@@ -27,6 +28,12 @@ const openaiApiKey = defineSecret('OPENAI_API_KEY');
 // Google Play Developer API 用サービスアカウント鍵（JSON文字列）。
 // 購入レシート検証（Issue #163）で使用。Secret Manager で管理。
 const googlePlayServiceAccount = defineSecret('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON');
+
+// App Store Server API 用認証情報（Issue #204）。Secret Manager で管理。
+// 取得方法: App Store Connect → ユーザーとアクセス → キー → App Store Connect API
+const appStoreKeyId = defineSecret('APP_STORE_KEY_ID');
+const appStoreIssuerId = defineSecret('APP_STORE_ISSUER_ID');
+const appStorePrivateKey = defineSecret('APP_STORE_PRIVATE_KEY');
 
 // Android 購入検証用クライアントを遅延初期化
 let _androidPurchaseDeps = null;
@@ -515,7 +522,11 @@ exports.checkIngredientSimilarity = onCall(
 // users/{uid}/purchases/premium_entitlement に isPremium:true を書き込む
 // （admin SDK は Firestore ルールを迂回するため、クライアントは書き込めない）。
 exports.verifyPurchase = onCall(
-  { memory: '256MiB', timeoutSeconds: 30, secrets: [googlePlayServiceAccount] },
+  {
+    memory: '256MiB',
+    timeoutSeconds: 30,
+    secrets: [googlePlayServiceAccount, appStoreKeyId, appStoreIssuerId, appStorePrivateKey],
+  },
   async (request) => {
     // 認証チェック
     if (!request.auth) {
@@ -533,19 +544,70 @@ exports.verifyPurchase = onCall(
       );
     }
 
+    const uid = request.auth.uid;
+
+    // iOS: App Store Server API で検証（Issue #204）
     if (platform === 'ios') {
-      // TODO(#163): App Store Server API による iOS 検証は未対応。
-      // iOS リリース時に android_verifier.js と同様の ios_verifier.js を追加する。
-      throw new HttpsError('unimplemented', 'iOSのサーバー検証は未対応です');
+      let iosResult;
+      try {
+        iosResult = await verifyIosPurchase(
+          { productId, purchaseToken },
+          {
+            keyId: appStoreKeyId.value(),
+            issuerId: appStoreIssuerId.value(),
+            privateKey: appStorePrivateKey.value(),
+          }
+        );
+      } catch (error) {
+        logger.error('iOS購入検証で予期せぬエラー', { uid, error: error.message });
+        throw new HttpsError('internal', '購入検証に失敗しました');
+      }
+
+      if (!iosResult.valid) {
+        logger.warn('iOS購入検証に失敗（プレミアム付与せず）', {
+          uid, productId, reason: iosResult.reason,
+        });
+        if (iosResult.reason === 'api_error') {
+          throw new HttpsError(
+            'unavailable',
+            '検証サーバーに接続できませんでした。時間をおいて再試行してください'
+          );
+        }
+        throw new HttpsError('permission-denied', '購入を検証できませんでした');
+      }
+
+      await admin
+        .firestore()
+        .collection('users')
+        .doc(uid)
+        .collection('purchases')
+        .doc('premium_entitlement')
+        .set(
+          {
+            isPremium: true,
+            productId,
+            platform: 'ios',
+            originalTransactionId: iosResult.originalTransactionId || null,
+            verifiedAt: admin.firestore.FieldValue.serverTimestamp(),
+          },
+          { merge: true }
+        );
+
+      logger.info('iOS購入検証成功・エンタイトルメント付与', {
+        uid,
+        productId,
+        originalTransactionId: iosResult.originalTransactionId,
+      });
+
+      return { verified: true };
     }
+
     if (platform !== 'android') {
       throw new HttpsError(
         'invalid-argument',
         `未対応のプラットフォーム: ${platform}`
       );
     }
-
-    const uid = request.auth.uid;
 
     let result;
     try {

--- a/functions/purchase/ios_verifier.js
+++ b/functions/purchase/ios_verifier.js
@@ -102,6 +102,11 @@ function fetchTransaction(transactionId, jwt) {
       });
     });
 
+    // Cloud Functions タイムアウト(30s)の 2/3 で打ち切り、
+    // クライアントへのエラー応答時間を確保する
+    req.setTimeout(20000, () => {
+      req.destroy(new Error('request_timeout'));
+    });
     req.on('error', reject);
     req.end();
   });

--- a/functions/purchase/ios_verifier.js
+++ b/functions/purchase/ios_verifier.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * iOS（App Store）の購入レシート検証ロジック。
+ *
+ * App Store Server API v1 の GET /inApps/v1/transactions/{transactionId} を
+ * 使い、購入トークン（transactionId）をAppleサーバーで検証する。
+ *
+ * 必要な外部設定（Secret Manager に登録・defineSecret() で注入）:
+ * - APP_STORE_KEY_ID: App Store Connect Key ID（.p8に対応する英数字ID）
+ * - APP_STORE_ISSUER_ID: App Store Connect Issuer ID（UUID形式）
+ * - APP_STORE_PRIVATE_KEY: .p8ファイルの内容（"-----BEGIN PRIVATE KEY-----..."）
+ *
+ * Issue #204 対応: android_verifier.js と対称な構造で実装。
+ */
+
+const crypto = require('crypto');
+const https = require('https');
+
+/** アプリの Bundle ID（ios/Runner/Info.plist の CFBundleIdentifier）。 */
+const BUNDLE_ID = 'com.ikcoding.maikago';
+
+/** プレミアム有効化に対応する商品ID（Android と共通）。 */
+const VALID_PRODUCT_IDS = new Set(['maikago_premium_unlock']);
+
+/** App Store Server API のベースホスト。 */
+const APP_STORE_API_HOST = 'api.storekit.itunes.apple.com';
+
+/**
+ * App Store Server API 用の署名付きJWT（Bearer トークン）を生成する。
+ *
+ * アルゴリズム: ES256（ECDSAキー、SHA-256ハッシュ）
+ * Appleの要件: https://developer.apple.com/documentation/appstoreserverapi/generating_tokens_for_api_requests
+ *
+ * @param {string} keyId - App Store Connect Key ID
+ * @param {string} issuerId - App Store Connect Issuer ID
+ * @param {string} privateKeyPem - .p8 PEM文字列
+ * @returns {string} JWT文字列
+ */
+function generateAppStoreJWT(keyId, issuerId, privateKeyPem) {
+  const now = Math.floor(Date.now() / 1000);
+
+  const header = base64urlEncode(
+    JSON.stringify({ alg: 'ES256', kid: keyId, typ: 'JWT' })
+  );
+  const payload = base64urlEncode(
+    JSON.stringify({
+      iss: issuerId,
+      iat: now,
+      exp: now + 3600,
+      aud: 'appstoreconnect-v1',
+      bid: BUNDLE_ID,
+    })
+  );
+
+  const signingInput = `${header}.${payload}`;
+  const sign = crypto.createSign('SHA256');
+  sign.update(signingInput);
+  // ieee-p1363 形式（r||s）→ base64url に変換（ES256 標準形式）
+  const signature = sign
+    .sign({ key: privateKeyPem, dsaEncoding: 'ieee-p1363' })
+    .toString('base64url');
+
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * App Store Server API を呼び出し、トランザクション情報を取得する。
+ *
+ * @param {string} transactionId - App Store が発行したトランザクションID
+ * @param {string} jwt - generateAppStoreJWT で生成したJWT
+ * @returns {Promise<Object>} パース済みのトランザクション情報
+ */
+function fetchTransaction(transactionId, jwt) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: APP_STORE_API_HOST,
+      path: `/inApps/v1/transactions/${encodeURIComponent(transactionId)}`,
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => { body += chunk; });
+      res.on('end', () => {
+        if (res.statusCode === 404) {
+          return reject(Object.assign(new Error('not_found'), { statusCode: 404 }));
+        }
+        if (res.statusCode !== 200) {
+          return reject(
+            Object.assign(new Error('api_error'), { statusCode: res.statusCode, body })
+          );
+        }
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          reject(new Error('parse_error'));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/**
+ * App Store Server API レスポンスの signedTransactionInfo（JWS）を
+ * デコードしてペイロードを返す。
+ *
+ * TLSで保護されたAppleサーバーからの応答なので、JWSペイロードを
+ * 信頼して base64url デコードする（署名チェーン検証は省略）。
+ *
+ * @param {string} signedTransactionInfo - JWS文字列
+ * @returns {Object} トランザクション情報のペイロード
+ */
+function decodeSignedTransaction(signedTransactionInfo) {
+  const parts = signedTransactionInfo.split('.');
+  if (parts.length !== 3) throw new Error('invalid_jws');
+  return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+}
+
+/**
+ * iOS の購入を検証する。
+ *
+ * @param {Object} params
+ * @param {string} params.productId - 購入された商品ID
+ * @param {string} params.purchaseToken - App Store が発行したトランザクションID
+ * @param {Object} deps
+ * @param {string} deps.keyId - App Store Connect Key ID（Secretから注入）
+ * @param {string} deps.issuerId - App Store Connect Issuer ID（Secretから注入）
+ * @param {string} deps.privateKey - .p8 PEM文字列（Secretから注入）
+ * @returns {Promise<{valid: boolean, reason?: string, originalTransactionId?: string}>}
+ */
+async function verifyIosPurchase({ productId, purchaseToken }, deps) {
+  if (!productId || !purchaseToken) {
+    return { valid: false, reason: 'missing_params' };
+  }
+
+  if (!VALID_PRODUCT_IDS.has(productId)) {
+    return { valid: false, reason: 'unknown_product' };
+  }
+
+  let jwt;
+  try {
+    jwt = generateAppStoreJWT(deps.keyId, deps.issuerId, deps.privateKey);
+  } catch (_e) {
+    return { valid: false, reason: 'jwt_error' };
+  }
+
+  let response;
+  try {
+    response = await fetchTransaction(purchaseToken, jwt);
+  } catch (err) {
+    if (err.statusCode === 404) return { valid: false, reason: 'not_found' };
+    return { valid: false, reason: 'api_error' };
+  }
+
+  let txInfo;
+  try {
+    txInfo = decodeSignedTransaction(response.signedTransactionInfo);
+  } catch {
+    return { valid: false, reason: 'decode_error' };
+  }
+
+  // 商品IDが一致するか確認
+  if (txInfo.productId !== productId) {
+    return { valid: false, reason: 'product_mismatch' };
+  }
+
+  // 取り消し済みトランザクションは無効
+  if (txInfo.revocationDate) {
+    return { valid: false, reason: 'revoked' };
+  }
+
+  return {
+    valid: true,
+    originalTransactionId: txInfo.originalTransactionId,
+  };
+}
+
+// ---- ヘルパー ----
+
+function base64urlEncode(str) {
+  return Buffer.from(str).toString('base64url');
+}
+
+module.exports = {
+  verifyIosPurchase,
+  generateAppStoreJWT,
+  BUNDLE_ID,
+  VALID_PRODUCT_IDS,
+};


### PR DESCRIPTION
## 概要

Issue #204（#163の残課題）のiOS対応。PR #211でAndroid検証は実装済みだったため、iOS検証を同じパターンで実装した。

## 変更内容

### `functions/purchase/ios_verifier.js`（新規）
- App Store Server API v1 `GET /inApps/v1/transactions/{transactionId}` を使った検証
- `android_verifier.js` と対称な `{valid, reason, originalTransactionId?}` 返値パターン
- Node.js組み込み `crypto`（JWT生成）・`https`（API呼び出し）のみ使用（依存追加なし）
- ES256アルゴリズムで App Store Connect APIのJWTを生成
- Apple API応答タイムアウト: 20秒（Cloud Functions 30秒タイムアウトの前に打ち切り）

### `functions/index.js`
- iOS分岐の `throw HttpsError('unimplemented')` → `verifyIosPurchase` 呼び出しに置き換え
- `secrets` に `APP_STORE_KEY_ID`, `APP_STORE_ISSUER_ID`, `APP_STORE_PRIVATE_KEY` を追加
- 検証成功時に Admin SDK で `premium_entitlement` をサーバー側で書き込む（Androidと同構造）

## 本番動作に必要な外部設定（IK側）
1. App Store Connect → ユーザーとアクセス → キー → App Store Connect API でキー（.p8）を発行
2. Firebase Secret Manager に以下を登録:
   - `APP_STORE_KEY_ID`: キーID（英数字10文字）
   - `APP_STORE_ISSUER_ID`: Issuer ID（UUID形式）
   - `APP_STORE_PRIVATE_KEY`: .p8ファイルの内容（BEGIN PRIVATE KEY から EOF まで）
3. `firebase deploy --only functions` でデプロイ

## セキュリティ
- Apple API はTLS接続のため、レスポンスJWSの署名チェーン検証は省略（TLS信頼に依存）
- logger に秘密情報（private key等）は出力しない
- Firestore への premium_entitlement 書き込みは Admin SDK（ルールをバイパス）のみが実行

## テスト
- `flutter analyze`: エラー0
- `flutter test --exclude-tags=integration`: 477件 全件パス

Closes #204