### PR TITLE
test(#168): 計算境界値・widget testを追加

### DIFF
--- a/test/providers/managers/sync_tab_manager_test.dart
+++ b/test/providers/managers/sync_tab_manager_test.dart
@@ -164,6 +164,36 @@ void main() {
       // 単価で丸める旧実装なら (101*0.5).round()=51 → ×3 = 153 とズレていた
       expect(manager.getDisplayTotal(shop), 152);
     });
+
+    test('discount=0.0（割引なし）は価格×個数のまま', () {
+      final shop = createSampleShop(items: [
+        createSampleItem(
+            price: 999, quantity: 3, discount: 0.0, isChecked: true),
+      ]);
+
+      // 999 * 3 * 1.0 = 2997
+      expect(manager.getDisplayTotal(shop), 2997);
+    });
+
+    test('discount=1.0（100%割引）は0になる', () {
+      final shop = createSampleShop(items: [
+        createSampleItem(
+            price: 500, quantity: 2, discount: 1.0, isChecked: true),
+      ]);
+
+      // 500 * 2 * 0.0 = 0
+      expect(manager.getDisplayTotal(shop), 0);
+    });
+
+    test('大きな金額でもオーバーフローしない', () {
+      final shop = createSampleShop(items: [
+        createSampleItem(
+            price: 9999999, quantity: 99, discount: 0.0, isChecked: true),
+      ]);
+
+      // 9999999 * 99 = 989999901（intの範囲内）
+      expect(manager.getDisplayTotal(shop), 989999901);
+    });
   });
 
   group('getSharedTabTotal', () {

--- a/test/screens/main/widgets/empty_state_guide_test.dart
+++ b/test/screens/main/widgets/empty_state_guide_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:maikago/screens/main/widgets/empty_state_guide.dart';
+
+void main() {
+  group('EmptyStateGuide', () {
+    testWidgets('エラーなくレンダリングされる', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateGuide(),
+          ),
+        ),
+      );
+
+      expect(find.byType(EmptyStateGuide), findsOneWidget);
+    });
+
+    testWidgets('買い物カートアイコンが表示される', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateGuide(),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.shopping_cart_outlined), findsOneWidget);
+    });
+
+    testWidgets('dispose後にエラーが発生しない（AnimationControllerのリーク確認）',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStateGuide(),
+          ),
+        ),
+      );
+
+      // 別のウィジェットに切り替えてdisposeを発火させる
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(),
+          ),
+        ),
+      );
+
+      // エラーなく完了することを確認
+    });
+  });
+}

--- a/test/screens/ocr_result_item_widgets/ocr_result_empty_state_test.dart
+++ b/test/screens/ocr_result_item_widgets/ocr_result_empty_state_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:maikago/screens/main/widgets/empty_state_purchased_guide.dart';
+
+void main() {
+  group('EmptyStatePurchasedGuide', () {
+    testWidgets('エラーなくレンダリングされる', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStatePurchasedGuide(),
+          ),
+        ),
+      );
+
+      expect(find.byType(EmptyStatePurchasedGuide), findsOneWidget);
+    });
+
+    testWidgets('dispose後にエラーが発生しない（AnimationControllerのリーク確認）',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EmptyStatePurchasedGuide(),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

Issue #168（テスト拡充）の対応。

## 追加テスト

### `sync_tab_manager_test.dart` — 境界値3件追加
| テスト | 検証内容 |
|---|---|
| `discount=0.0（割引なし）は価格×個数のまま` | 割引なしの通常ケース明示 |
| `discount=1.0（100%割引）は0になる` | `(price * qty * 0.0).round() = 0` を確認 |
| `大きな金額でもオーバーフローしない` | `9999999 × 99 = 989999901`（int64範囲内） |

### `test/screens/main/widgets/empty_state_guide_test.dart` — 新規3件
- `EmptyStateGuide` のレンダリング・アイコン表示・AnimationController dispose確認

### `test/screens/ocr_result_item_widgets/ocr_result_empty_state_test.dart` — 新規2件
- `EmptyStatePurchasedGuide` のレンダリング・dispose確認

## テスト結果
- `flutter analyze`: エラー0
- `flutter test --exclude-tags=integration`: 485件 全件パス（元477件＋新規8件）

Closes #168