### PR TITLE
fix: ListItemEditDialogの保存時に自動購入済みロジックを追加

### DIFF
--- a/lib/widgets/list_item_edit_dialog.dart
+++ b/lib/widgets/list_item_edit_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:maikago/models/list.dart';
+import 'package:maikago/services/settings_persistence.dart';
 import 'package:maikago/utils/calculation_utils.dart';
 import 'package:maikago/utils/input_formatters.dart';
 import 'package:maikago/widgets/common_dialog.dart';
@@ -89,6 +90,25 @@ class _ListItemEditDialogState extends State<ListItemEditDialog> {
     setState(() {
       _name = value;
     });
+  }
+
+  Future<void> _handleSave() async {
+    final onUpdate = widget.onUpdate;
+    final isAutoCompleteEnabled = await SettingsPersistence.loadAutoComplete();
+    final shouldAutoComplete =
+        isAutoCompleteEnabled && _price > 0 && !widget.item.isChecked;
+
+    final updatedListItem = widget.item.copyWith(
+      name: _name.trim(),
+      quantity: _quantity,
+      price: _price,
+      discount: _discount,
+      isChecked: shouldAutoComplete ? true : widget.item.isChecked,
+    );
+
+    if (!mounted) return;
+    context.pop();
+    onUpdate?.call(updatedListItem);
   }
 
   void _showDeleteConfirmation(BuildContext context) {
@@ -300,18 +320,8 @@ class _ListItemEditDialogState extends State<ListItemEditDialog> {
         CommonDialog.destructiveButton(context, label: '削除', onPressed: () {
           _showDeleteConfirmation(context);
         }),
-        CommonDialog.primaryButton(context, label: '保存', onPressed: () {
-          context.pop();
-          // 更新されたアイテムを作成
-          final updatedListItem = widget.item.copyWith(
-            name: _name.trim(),
-            quantity: _quantity,
-            price: _price,
-            discount: _discount,
-          );
-          // 更新処理を実行
-          widget.onUpdate?.call(updatedListItem);
-        }),
+        CommonDialog.primaryButton(context,
+            label: '保存', onPressed: _handleSave),
       ],
     );
   }

--- a/test/widgets/list_item_edit_dialog_test.dart
+++ b/test/widgets/list_item_edit_dialog_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:maikago/models/list.dart';
+import 'package:maikago/widgets/list_item_edit_dialog.dart';
+
+ListItem _item({int price = 0, bool isChecked = false}) => ListItem(
+      id: 'test-1',
+      name: 'テストアイテム',
+      quantity: 1,
+      price: price,
+      discount: 0,
+      shopId: 'shop-1',
+      isChecked: isChecked,
+    );
+
+/// GoRouter 付きでダイアログを表示し、保存ボタンを押す。
+/// onUpdate コールバックで受け取った ListItem を返す。
+Future<ListItem?> _tapSave(WidgetTester tester, ListItem item) async {
+  ListItem? result;
+
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(
+          body: Builder(
+            builder: (ctx) => ElevatedButton(
+              onPressed: () => showDialog<void>(
+                context: ctx,
+                builder: (_) => ListItemEditDialog(
+                  item: item,
+                  onUpdate: (updated) => result = updated,
+                ),
+              ),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+  await tester.tap(find.text('open'));
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.text('保存'));
+  await tester.pumpAndSettle();
+
+  return result;
+}
+
+void main() {
+  group('ListItemEditDialog 自動購入済み', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    testWidgets('自動購入済みON・price>0・未チェック → 保存後 isChecked:true（バグ再発防止）',
+        (tester) async {
+      SharedPreferences.setMockInitialValues(
+          {'auto_complete_on_price_input': true});
+
+      final result =
+          await _tapSave(tester, _item(price: 100, isChecked: false));
+
+      expect(result?.isChecked, isTrue);
+    });
+
+    testWidgets('自動購入済みOFF・price>0・未チェック → 保存後 isChecked:false',
+        (tester) async {
+      SharedPreferences.setMockInitialValues(
+          {'auto_complete_on_price_input': false});
+
+      final result =
+          await _tapSave(tester, _item(price: 100, isChecked: false));
+
+      expect(result?.isChecked, isFalse);
+    });
+
+    testWidgets('自動購入済みON・price=0・未チェック → 保存後 isChecked:false', (tester) async {
+      SharedPreferences.setMockInitialValues(
+          {'auto_complete_on_price_input': true});
+
+      final result = await _tapSave(tester, _item(price: 0, isChecked: false));
+
+      expect(result?.isChecked, isFalse);
+    });
+
+    testWidgets('自動購入済みON・price>0・購入済み → 保存後 isChecked:true（状態維持）',
+        (tester) async {
+      SharedPreferences.setMockInitialValues(
+          {'auto_complete_on_price_input': true});
+
+      final result = await _tapSave(tester, _item(price: 100, isChecked: true));
+
+      expect(result?.isChecked, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

- UI改修（`c45312c6`）で新設した `ListItemEditDialog` に、詳細設定の「金額入力時の自動購入済み」機能のロジックが欠落していたバグを修正。
- 旧 `ItemEditDialog._handleSave()` にはあったロジックが、新ダイアログへのコピー時に抜け落ちていた。

## 原因

`ListItemEditDialog` の保存ボタンがインライン同期クロージャで実装されており、`SettingsPersistence.loadAutoComplete()` を一切呼ばずに `copyWith` で `isChecked` を更新しないまま保存していた。

## 修正内容

- `_handleSave()` async メソッドを追加
- 保存時に `loadAutoComplete()` を読み、`price > 0 && !isChecked` の条件を満たす場合に `isChecked: true` をセット
- 再発防止テスト4件を追加

## テスト計画

- [x] `flutter analyze` エラー0
- [x] `flutter test` 全512件パス（新規4件含む）
- [ ] 実機で「詳細設定 → 自動購入済みON → アイテムタップ → 金額入力 → 保存」で購入済みに移動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)