### PR TITLE
fix: MainScreenのリスナー登録順序とTabController初期同期を修正

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -136,8 +136,12 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
       loadSavedTabIndex();
       final dataProvider = context.read<DataProvider>();
       final authProvider = context.read<AuthProvider>();
-      dataProvider.setAuthProvider(authProvider);
+      // リスナーを先に登録してから setAuthProvider を呼ぶ（同期通知を取りこぼさないため）
       dataProvider.addListener(_onDataProviderChanged);
+      dataProvider.setAuthProvider(authProvider);
+      // データが既にロード済みの場合（setAuthProvider が早期リターンするケース等）に
+      // TabController の length を即時同期する
+      _onDataProviderChanged();
     });
   }
 
@@ -353,7 +357,9 @@ class _MainScreenState extends State<MainScreen> with TickerProviderStateMixin {
             drawerTextColor:
                 currentTheme == 'dark' ? theme.colorScheme.onPrimary : null,
             onCustomColorsChanged: updateCustomColors,
-            onSettingsReturned: () {},
+            onSettingsReturned: () {
+              _loadStrikethroughSetting();
+            },
           ),
           body: ItemListSection(
             shop: shop,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -740,10 +740,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1113,10 +1113,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   tutorial_coach_mark:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## 変更内容

- `addListener` を `setAuthProvider` より先に登録し、同期通知の取りこぼしを防ぐ
- `setAuthProvider` 後に `_onDataProviderChanged()` を即時呼び出し、データロード済み時の `TabController` 長さを同期
- `onSettingsReturned` で取り消し線設定をリロード

## 背景

`setAuthProvider` 内部で同期的にリスナーへ通知が飛ぶケースがあり、リスナー登録前に通知が来ると取りこぼしが発生していた。

## テスト

- [ ] flutter analyze
- [ ] flutter test