### PR TITLE
fix: CIビルドにADMOB_BANNER_AD_UNIT_IDをdart-defineで注入する

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -63,7 +63,8 @@ workflows:
           flutter build ipa --release \
             --build-name=$VERSION \
             --build-number=$BUILD_NUMBER \
-            --export-options-plist=/Users/builder/export_options.plist
+            --export-options-plist=/Users/builder/export_options.plist \
+            --dart-define=ADMOB_BANNER_AD_UNIT_ID=$ADMOB_BANNER_AD_UNIT_ID
 
     artifacts:
       - build/ios/ipa/*.ipa
@@ -131,7 +132,8 @@ workflows:
           echo "Building version $VERSION+$BUILD_NUMBER"
           flutter build appbundle --release \
             --build-name=$VERSION \
-            --build-number=$BUILD_NUMBER
+            --build-number=$BUILD_NUMBER \
+            --dart-define=ADMOB_BANNER_AD_UNIT_ID=$ADMOB_BANNER_AD_UNIT_ID
 
     artifacts:
       - build/**/outputs/**/*.aab


### PR DESCRIPTION
## 問題

`--dart-define=ADMOB_BANNER_AD_UNIT_ID` が両ワークフローに渡されていなかった。
`String.fromEnvironment` はビルド時定数のため、CI環境変数があっても渡さないと届かない。
結果として全配信済みバージョンでテスト広告ID（`ca-app-pub-3940256099942544/6300978111`）が使われていた。

## 修正

`ios-release` / `android-release` 両ワークフローのビルドコマンドに追加：
```
--dart-define=ADMOB_BANNER_AD_UNIT_ID=$ADMOB_BANNER_AD_UNIT_ID
```

## Codemagicダッシュボードで必要な作業

- `ios_signing` グループに `ADMOB_BANNER_AD_UNIT_ID` = iOSのバナー広告ユニットID を追加
- `google_play_credentials` グループに `ADMOB_BANNER_AD_UNIT_ID` = AndroidのバナーID を追加

AdMobダッシュボード → アプリ → 広告ユニット で各プラットフォームのIDを確認。