### PR TITLE
chore: バージョンを1.6.1+63に更新・広告修正の更新履歴を追加

### DIFF
--- a/lib/models/release_history.dart
+++ b/lib/models/release_history.dart
@@ -40,6 +40,16 @@ class ReleaseHistory {
   /// 更新履歴の静的データ（新しいバージョンを先頭に追加）
   static final List<ReleaseNote> _releaseNotes = [
     ReleaseNote(
+      version: '1.6.1',
+      releaseDate: DateTime(2026, 6, 18),
+      changes: [
+        const ChangeItem(
+          description: '広告が正しく表示されない問題を修正しました。',
+          category: ChangeCategory.bugFix,
+        ),
+      ],
+    ),
+    ReleaseNote(
       version: '1.6.0',
       releaseDate: DateTime(2026, 6, 18),
       changes: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maikago
 description: "まいカゴ – 買いすぎ防止のための買い物リスト管理アプリ"
 publish_to: 'none'
-version: 1.6.0+62
+version: 1.6.1+63
 environment:
   sdk: '>=3.0.0 <4.0.0'
 


### PR DESCRIPTION
## 変更内容

- `pubspec.yaml`: `1.6.0+62` → `1.6.1+63`
- `release_history.dart`: 1.6.1のエントリを追加

## 背景

1.6.0（versionCode=62）が既にGoogle Playに公開済みのため、バージョンコードを63に更新。
今回の実質的な変更はPR #220（AdMob広告IDのdart-define注入）。