### PR TITLE
chore: Google Play Billing Library 8.0.0対応

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -636,18 +636,18 @@ packages:
     dependency: "direct main"
     description:
       name: in_app_purchase
-      sha256: "5cddd7f463f3bddb1d37a72b95066e840d5822d66291331d7f8f05ce32c24b6c"
+      sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.3.0"
   in_app_purchase_android:
     dependency: transitive
     description:
       name: in_app_purchase_android
-      sha256: abb254ae159a5a9d4f867795ecb076864faeba59ce015ab81d4cca380f23df45
+      sha256: b8af1b6f0e57076b5da5ede71e3af2d727017c0416ad2a41017c6ed2b102381d
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0+8"
+    version: "0.5.0"
   in_app_purchase_platform_interface:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Google Playが2026-08-31までにアプリ更新にBilling Library 8.0.0以上を必須化する通知への対応
- `in_app_purchase` を 3.2.3 → 3.3.0 に更新（依存の `in_app_purchase_android` が 0.4.0+8 → 0.5.0 となり、内部で使用するBilling Libraryが7.1.1 → 8.0.0に更新される）
- `pubspec.yaml` の制約 `^3.2.3` の範囲内で解決するため、コード側の変更は不要
- Billing Library 8で削除された `queryPurchaseHistory` 系APIは未使用のため影響なし

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test --exclude-tags=integration` 全件パス
- [x] `flutter build web --release` 成功（Web影響なし）
- [ ] Android実機/CIでのビルド確認（ローカル環境にAndroid SDKがないため未実施）
- [ ] 購入・復元フローの実機動作確認（特に `restorePurchases`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JA7r2Am4fNfDqhQUAq3gPt