### PR TITLE
chore: バージョンを1.6.2+64に更新

### DIFF
--- a/lib/models/release_history.dart
+++ b/lib/models/release_history.dart
@@ -40,6 +40,16 @@ class ReleaseHistory {
   /// 更新履歴の静的データ（新しいバージョンを先頭に追加）
   static final List<ReleaseNote> _releaseNotes = [
     ReleaseNote(
+      version: '1.6.2',
+      releaseDate: DateTime(2026, 7, 22),
+      changes: [
+        const ChangeItem(
+          description: '内部ライブラリを更新し、安定性を改善しました。',
+          category: ChangeCategory.other,
+        ),
+      ],
+    ),
+    ReleaseNote(
       version: '1.6.1',
       releaseDate: DateTime(2026, 6, 18),
       changes: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: maikago
 description: "まいカゴ – 買いすぎ防止のための買い物リスト管理アプリ"
 publish_to: 'none'
-version: 1.6.1+63
+version: 1.6.2+64
 environment:
   sdk: '>=3.0.0 <4.0.0'
 


### PR DESCRIPTION
## Summary
- #223 (Google Play Billing Library 8.0.0対応) を本番反映するためのバージョンbump
- `1.6.1+63` は既にGoogle Playの本番トラックに公開済みのため、同じbuild numberでは再アップロードできない
- `pubspec.yaml`: 1.6.1+63 → 1.6.2+64
- `lib/models/release_history.dart` にアプリ内更新履歴を追加

## Test plan
- [x] `flutter analyze` エラー0件
- [x] `flutter test --exclude-tags=integration` 全件パス

マージ後、Codemagicダッシュボードから `android-release` ワークフローを手動起動してください（`google_play.track: production` のため、マージ後に本番へ直接公開されます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JA7r2Am4fNfDqhQUAq3gPt